### PR TITLE
Feature/#3 member crud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ application-local.yml
 ### Claude Code (로컬 전용) ###
 .bkit*
 .pdca*
+
+### 코드 보관/기록용
+/patches/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 ## 5. 문서 및 API 명세
 - [요구사항 명세서](/docs/Requirements.md)
 - [ERD 다이어그램](/docs/ERD.md)
+- [개발 가이드](/docs/DEVELOPMENT.md)
 - [API 명세서](http://localhost:8080/swagger-ui/index.html)
 - [API 문서](http://localhost:8080/v3/api-docs)
 

--- a/docs/Business-Dictionary.md
+++ b/docs/Business-Dictionary.md
@@ -12,7 +12,7 @@
 | | | | | | | |
 | MEMBER   | 인원       | Member              | 인원        | 관리자 입력    | member                  | 블로그 포스팅 수를 관리하는 대상 사용자      | soft delete 적용                      |
 | MEMBER   | 닉네임      | Nickname            | 닉네임       | 관리자 입력    | member.nickname         | 블로그 사용자 식별용 고유 이름           | UNIQUE                              |
-| MEMBER   | 삭제일시     | DeletedAt           | 삭제일시      | 시스템 처리    | member.deleted_at       | soft delete 처리 시 기록되는 시각    | NULL이면 활성 상태                        |
+| MEMBER   | 삭제여부     | Deleted             | 삭제여부      | 시스템 처리    | member.deleted          | soft delete 여부                  | false면 활성 상태                        |
 | MEMBER   | 생성일시     | CreatedAt           | 생성일시      | 시스템 자동 생성 | member.created_at       | 데이터 최초 생성 시 기록되는 시각         | DEFAULT CURRENT_TIMESTAMP           |
 | MEMBER   | 수정일시     | UpdatedAt           | 수정일시      | 시스템 자동 갱신 | member.updated_at       | 데이터 수정 시 갱신되는 시각            | ON UPDATE CURRENT_TIMESTAMP         |
 | | | | | | | |
@@ -33,5 +33,3 @@
 | 명칭           | 정의                               |
 | ------------ |----------------------------------|
 | 주간 집계        | 한 주의 포스팅 수를 그 다음주 월요일 00:01 에 집계 |
-
-

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Amazon2 프로젝트에 기여하실 때 따라야 할 규칙들입니다.
 | `Fix`      | 버그 수정                       | `Fix: 요일 계산 오류 수정`       |
 | `Docs`     | 문서 작성/수정 (코드 제외)            | `Docs: API 접속 링크 추가`     |
 | `Config`   | 설정 파일 변경                    | `Config: Swagger 경로 설정`  |
+| `Test`     | 테스트 코드 작성/수정                | `Test: 회원 API 테스트 추가`    |
 | `Chore`    | 코드와 무관한 작업 (import 정리, 의존성) | `Chore: 불필요한 import 제거`  |
 | `Refactor` | 코드 구조 개선 (동작 변경 없음)         | `Refactor: 중복 로직 추출`     |
 | `Build`    | 빌드 시스템, 의존성 변경              | `Build: 의존성 추가`          |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,110 @@
+# 로컬 개발 가이드 (Local Development Guide)
+
+이 문서는 프로젝트의 로컬 개발 환경 설정 및 유용한 팁을 제공합니다.
+
+---
+
+## 1. 로컬 변경사항 관리 (Managing Local Changes)
+
+때로는 커밋하지 않고 임시로 변경사항을 저장해야 할 때가 있습니다. `git stash`는 좋은 방법이지만, 여러 변경사항을 관리하기에는 불편할 수 있습니다.
+
+이 프로젝트에서는 `.gitignore`에 등록된 `patches/` 디렉토리를 사용하여 로컬 변경사항을 파일로 관리하는 방법을 권장합니다.
+
+### 목적
+
+- `git stash`의 복잡함을 피하고, 여러 변경사항을 이름이 있는 파일로 명확하게 관리합니다.
+- 아직 커밋하기에는 이르지만, 다른 브랜치로 전환하기 전에 현재 작업을 백업하고 싶을 때 유용합니다.
+
+### 사용 방법
+
+#### 1. 패치 파일 생성하기 (현재 변경사항 저장)
+
+현재 작업 디렉토리의 변경사항(Staged되지 않은 변경사항)을 `.patch` 파일로 저장합니다.
+
+```bash
+git diff > patches/my-feature-in-progress.patch
+```
+
+> **팁:** 패치 파일의 이름은 작업 내용을 알 수 있도록 명확하게 짓는 것이 좋습니다. (예: `refactor-member-service.patch`)
+
+#### 2. 패치 파일 적용하기 (저장한 변경사항 불러오기)
+
+저장해둔 패치 파일을 현재 작업 디렉토리에 적용합니다.
+
+```bash
+git apply patches/my-feature-in-progress.patch
+```
+
+#### 3. 패치 적용 취소하기
+
+적용했던 패치 파일의 내용을 다시 원래대로 되돌립니다.
+
+```bash
+git apply -R patches/my-feature-in-progress.patch
+```
+
+### GitHub Gist를 활용한 패치 공유
+
+로컬 변경사항을 다른 개발자와 공유하거나, 여러 기기에서 동기화하고 싶을 때는 GitHub Gist를 활용할 수 있습니다.
+
+1.  **Gist 생성:** [GitHub Gist](https://gist.github.com/)에서 새 Gist를 생성합니다.
+2.  **패치 파일 업로드:** 생성한 `.patch` 파일의 내용을 복사하여 Gist에 붙여넣거나 파일을 업로드합니다.
+3.  **패치 적용:** Gist의 'Raw' 버튼을 클릭하여 URL을 복사한 후, 아래 명령어로 적용합니다.
+    *   **주의:** Gist URL 뒤에 `/raw/<파일명>`까지 포함된 주소를 사용해야 합니다. (HTML 페이지가 아닌 순수 파일 내용을 가져오기 위함)
+
+```bash
+# 예시: curl -L https://gist.github.com/user/gist_id/raw/filename.patch | git apply
+curl -L <Gist Raw URL>/raw/<filename.patch> | git apply
+```
+
+### 주의사항
+
+- `patches/` 디렉토리는 `.gitignore`에 등록되어 있으므로, 이 디렉토리의 파일들은 원격 저장소에 푸시되지 않습니다. **개인 로컬 환경에서만 사용해야 합니다.**
+- 패치 파일은 생성 시점의 코드 상태에 의존적입니다. 원본 코드가 많이 변경되면 패치가 적용되지 않을 수 있습니다.
+- 컨플릭트(Conflict)가 발생하면 `git apply`는 실패하며, 수동으로 해결해야 합니다.
+
+---
+
+## 2. Git Worktree 활용 (Working with Multiple Branches)
+
+`git worktree`를 사용하면 하나의 저장소에서 여러 브랜치를 동시에 체크아웃하여 작업할 수 있습니다. 브랜치 전환(`git checkout`) 없이 핫픽스 처리나 코드 리뷰를 동시에 진행할 때 유용합니다.
+
+### 사용 방법
+
+#### 1. 새 워크트리 생성 (새 브랜치와 함께)
+
+```bash
+# git worktree add <path> <branch>
+git worktree add ../amazon2-hotfix hotfix/urgent-bug-fix
+```
+위 명령어는 현재 프로젝트 상위 디렉토리에 `amazon2-hotfix`라는 폴더를 만들고, 그곳에 `hotfix/urgent-bug-fix` 브랜치를 체크아웃합니다.
+
+#### 2. 기존 브랜치로 워크트리 생성
+
+```bash
+git worktree add ../amazon2-review feature/new-login
+```
+
+#### 3. 워크트리 목록 확인
+
+```bash
+git worktree list
+```
+
+#### 4. 워크트리 삭제
+
+작업이 끝난 워크트리 디렉토리를 삭제하고, git 정보를 정리합니다.
+
+```bash
+# 1. 디렉토리 삭제
+rm -rf ../amazon2-hotfix
+
+# 2. 워크트리 정보 정리
+git worktree prune
+```
+
+### 활용 팁
+
+- **긴급 버그 수정:** 현재 작업 중인 내용을 `stash`하거나 커밋하지 않고, 별도 워크트리에서 핫픽스 브랜치를 띄워 수정 후 바로 푸시할 수 있습니다.
+- **코드 리뷰:** PR이 올라온 브랜치를 별도 워크트리로 띄워놓고, 로컬에서 직접 실행해보며 리뷰할 수 있습니다.
+- **의존성 격리:** 서로 다른 자바 버전이나 라이브러리 버전을 테스트해야 할 때 유용합니다.

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -5,7 +5,7 @@ erDiagram
 
     BLOG_CATEGORY {
         VARCHAR(10) code PK
-        VARCHAR(50) name
+        VARCHAR(50) name "UK"
         VARCHAR(50) description
         BOOLEAN deleted
         DATETIME created_at
@@ -15,7 +15,7 @@ erDiagram
     MEMBER {
         BIGINT id PK
         VARCHAR(10) category_code FK
-        VARCHAR(50) nickname
+        VARCHAR(50) nickname "UK"
         BOOLEAN deleted
         DATETIME created_at
         VARCHAR(50) created_by
@@ -38,6 +38,6 @@ erDiagram
         VARCHAR(50) created_by
     }
 
-    BLOG_CATEGORY ||--o{ MEMBER : "category_code"
+    BLOG_CATEGORY |o--o{ MEMBER : "category_code"
     MEMBER ||--o{ POSTING : "member_id"
 ```

--- a/src/main/java/com/jk/amazon2/common/entity/BaseAudit.java
+++ b/src/main/java/com/jk/amazon2/common/entity/BaseAudit.java
@@ -1,0 +1,23 @@
+package com.jk.amazon2.common.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseAudit extends BaseCreation{
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    @Column(name = "updated_at", nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", nullable = false)
+    @LastModifiedBy
+    private String updatedBy;
+}

--- a/src/main/java/com/jk/amazon2/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/controller/MemberController.java
@@ -3,6 +3,10 @@ package com.jk.amazon2.controller;
 import com.jk.amazon2.controller.dto.MemberRequest;
 import com.jk.amazon2.controller.dto.MemberResponse;
 import com.jk.amazon2.controller.spec.MemberApiSpec;
+import com.jk.amazon2.service.MemberService;
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -18,6 +22,8 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 public class MemberController implements MemberApiSpec {
+    private final MemberService memberService;
+
     @Override
     @GetMapping("/members")
     public ResponseEntity<Page<MemberResponse.MemberDto>> getMembers(
@@ -47,18 +53,17 @@ public class MemberController implements MemberApiSpec {
 
     @Override
     @PostMapping("/members")
-    public ResponseEntity<MemberResponse.MemberDto> createMember(
-            @RequestBody MemberRequest.MemberDto memberDto
+    public ResponseEntity<MemberResponse.MemberCreateDto> createMember(
+            @RequestBody @Valid MemberRequest.MemberCreateDto request
     ) {
-        MemberResponse.MemberDto savedMember = new MemberResponse.MemberDto(
-                memberDto.nickname(),
-                memberDto.categoryCode(),
-                LocalDate.now(),
-                "active"
-        );
+        MemberCommand.Create command = MemberCommand.Create.of(request.nickname(), request.categoryCode());
+        var createdMember = memberService.create(command);
+
+        var response = MemberResponse.MemberCreateDto.from(createdMember);
+
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(savedMember);
+                .body(response);
     }
 
     @Override

--- a/src/main/java/com/jk/amazon2/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/controller/MemberController.java
@@ -22,6 +22,13 @@ public class MemberController implements MemberApiSpec {
     private final MemberService memberService;
 
     @Override
+    @GetMapping("/members/{id}")
+    public ResponseEntity<MemberResponse.MemberDetailDto> getMember(@PathVariable Long id) {
+        MemberResult.Detail result = memberService.findById(id);
+        return ResponseEntity.ok(MemberResponse.MemberDetailDto.from(result));
+    }
+
+    @Override
     @GetMapping("/members")
     public ResponseEntity<Page<MemberResponse.MemberListDto>> getMembers(
             MemberRequest.MemberSearchCondition searchCondition,

--- a/src/main/java/com/jk/amazon2/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/controller/MemberController.java
@@ -56,7 +56,7 @@ public class MemberController implements MemberApiSpec {
             @PathVariable Long id,
             @RequestBody MemberRequest.MemberDto member
     ) {
-        var update = MemberCommand.Update.of(member.nickname(), member.categoryCode());
+        var update = MemberCommand.Update.of(id, member.nickname(), member.categoryCode());
 
         var response = MemberResponse.MemberUpdateDto.from(memberService.update(update));
         return ResponseEntity

--- a/src/main/java/com/jk/amazon2/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/controller/MemberController.java
@@ -5,18 +5,16 @@ import com.jk.amazon2.controller.dto.MemberResponse;
 import com.jk.amazon2.controller.spec.MemberApiSpec;
 import com.jk.amazon2.service.MemberService;
 import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,29 +23,16 @@ public class MemberController implements MemberApiSpec {
 
     @Override
     @GetMapping("/members")
-    public ResponseEntity<Page<MemberResponse.MemberDto>> getMembers(
+    public ResponseEntity<Page<MemberResponse.MemberListDto>> getMembers(
             MemberRequest.MemberSearchCondition searchCondition,
-            @PageableDefault(size = 10, sort = "nickname") Pageable pageable
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        List<MemberResponse.MemberDto> content = List.of(
-                new MemberResponse.MemberDto("user1", "카테고리1", LocalDate.of(2026, 2, 10), "active"),
-                new MemberResponse.MemberDto("user2", "카테고리2", LocalDate.of(2026, 2, 11), "active")
-        );
-
-        Page<MemberResponse.MemberDto> data = new PageImpl<>(
-            content,
-            pageable,
-            content.size()
-        ).map(m -> new MemberResponse.MemberDto(
-                m.nickname(),
-                m.categoryName(),
-                m.joinDate(),
-                m.status()
-        ));
+        Page<MemberResult.Summary> results = memberService.findMembers(searchCondition, pageable);
+        Page<MemberResponse.MemberListDto> response = results.map(MemberResponse.MemberListDto::from);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(data);
+                .body(response);
     }
 
     @Override

--- a/src/main/java/com/jk/amazon2/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/controller/MemberController.java
@@ -5,7 +5,6 @@ import com.jk.amazon2.controller.dto.MemberResponse;
 import com.jk.amazon2.controller.spec.MemberApiSpec;
 import com.jk.amazon2.service.MemberService;
 import com.jk.amazon2.service.dto.MemberCommand;
-import com.jk.amazon2.service.dto.MemberResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -68,14 +67,16 @@ public class MemberController implements MemberApiSpec {
 
     @Override
     @PutMapping("/members/{id}")
-    public ResponseEntity<MemberResponse.MemberDto> updateMember(
+    public ResponseEntity<MemberResponse.MemberUpdateDto> updateMember(
             @PathVariable Long id,
             @RequestBody MemberRequest.MemberDto member
     ) {
-        MemberResponse.MemberDto updatedMember = new MemberResponse.MemberDto(member.nickname(), member.categoryCode(), LocalDate.now(), "active");
+        var update = MemberCommand.Update.of(member.nickname(), member.categoryCode());
+
+        var response = MemberResponse.MemberUpdateDto.from(memberService.update(update));
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(updatedMember);
+                .body(response);
     }
 
     @Override

--- a/src/main/java/com/jk/amazon2/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/controller/MemberController.java
@@ -76,6 +76,7 @@ public class MemberController implements MemberApiSpec {
     public ResponseEntity<Void> deleteMember(
             @PathVariable Long id
     ) {
+        memberService.delete(id);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();

--- a/src/main/java/com/jk/amazon2/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/controller/MemberController.java
@@ -81,4 +81,15 @@ public class MemberController implements MemberApiSpec {
                 .status(HttpStatus.NO_CONTENT)
                 .build();
     }
+
+    @Override
+    @DeleteMapping("/members/{id}/permanent")
+    public ResponseEntity<Void> hardDeleteMember(
+            @PathVariable Long id
+    ) {
+        memberService.hardDelete(id);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
 }

--- a/src/main/java/com/jk/amazon2/controller/dto/CategoryResponse.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/CategoryResponse.java
@@ -41,10 +41,4 @@ public class CategoryResponse {
             return new Info(info.getCode(), info.getName(), info.getDescription());
         }
     }
-
-    @Deprecated
-    public record CategoryDto(
-            String code,
-            String name
-    ) {}
 }

--- a/src/main/java/com/jk/amazon2/controller/dto/MemberRequest.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/MemberRequest.java
@@ -1,5 +1,8 @@
 package com.jk.amazon2.controller.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public class MemberRequest {
     public record MemberDto(
             String nickname,
@@ -11,4 +14,16 @@ public class MemberRequest {
             String category,
             String status
     ) {}
+
+    public record MemberCreateDto(
+            @NotBlank(message = "닉네임은 필수 입니다.")
+            @Size(max = 50, message = "닉네임은 최대 50자까지 입력 가능합니다.")
+            String nickname,
+            @NotBlank(message = "카테고리 코드는 필수 입니다.")
+            String categoryCode
+    ) {
+        public static MemberCreateDto of(String nickname, String categoryCode) {
+            return new MemberCreateDto(nickname, categoryCode);
+        }
+    }
 }

--- a/src/main/java/com/jk/amazon2/controller/dto/MemberRequest.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/MemberRequest.java
@@ -11,7 +11,7 @@ public class MemberRequest {
 
     public record MemberSearchCondition(
             String nickname,
-            String category,
+            String categoryCode,
             String status
     ) {}
 

--- a/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
@@ -37,4 +37,20 @@ public class MemberResponse {
             return new MemberUpdateDto(update.nickname(), update.categoryCode());
         }
     }
+
+    public record MemberListDto(
+            String nickname,
+            String categoryName,
+            LocalDate joinDate,
+            String status
+    ) {
+        public static MemberListDto from(MemberResult.Summary summary) {
+            return new MemberListDto(
+                    summary.nickname(),
+                    summary.categoryName(),
+                    summary.createdAt().toLocalDate(),
+                    summary.deleted() ? "deleted" : "active"
+            );
+        }
+    }
 }

--- a/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
@@ -1,8 +1,27 @@
 package com.jk.amazon2.controller.dto;
 
+import com.jk.amazon2.service.dto.MemberResult;
+
 import java.time.LocalDate;
 
 public class MemberResponse {
+    public record MemberCreateDto(
+            Long id,
+            String nickname,
+            String categoryCode,
+            LocalDate createdAt
+    ){
+        public static MemberCreateDto from(MemberResult.Detail detail) {
+            return new MemberCreateDto(
+                    detail.getId(),
+                    detail.getNickname(),
+                    detail.getCategoryCode(),
+                    detail.getCreatedAt().toLocalDate()
+            );
+        }
+    }
+    
+    @Deprecated
     public record MemberDto(
             String nickname,
             String categoryName,

--- a/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
@@ -20,14 +20,6 @@ public class MemberResponse {
             );
         }
     }
-    
-    @Deprecated
-    public record MemberDto(
-            String nickname,
-            String categoryName,
-            LocalDate joinDate,
-            String status
-    ) {}
 
     public record MemberUpdateDto (
             String nickname,

--- a/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
@@ -28,4 +28,13 @@ public class MemberResponse {
             LocalDate joinDate,
             String status
     ) {}
+
+    public record MemberUpdateDto (
+            String nickname,
+            String categoryCode
+    ){
+        public static MemberUpdateDto from(MemberResult.Update update) {
+            return new MemberUpdateDto(update.nickname(), update.categoryCode());
+        }
+    }
 }

--- a/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
+++ b/src/main/java/com/jk/amazon2/controller/dto/MemberResponse.java
@@ -38,6 +38,24 @@ public class MemberResponse {
         }
     }
 
+    public record MemberDetailDto(
+            Long id,
+            String nickname,
+            String categoryCode,
+            LocalDate joinDate,
+            String status
+    ) {
+        public static MemberDetailDto from(MemberResult.Detail detail) {
+            return new MemberDetailDto(
+                    detail.getId(),
+                    detail.getNickname(),
+                    detail.getCategoryCode(),
+                    detail.getCreatedAt().toLocalDate(),
+                    detail.isDeleted() ? "deleted" : "active"
+            );
+        }
+    }
+
     public record MemberListDto(
             String nickname,
             String categoryName,

--- a/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
+++ b/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
@@ -20,7 +20,7 @@ public interface MemberApiSpec {
     );
     @Operation(summary = "유저 추가")
     @ApiResponse(responseCode = "201", description = "유저 추가 성공")
-    ResponseEntity<MemberResponse.MemberDto> createMember(MemberRequest.MemberDto memberDto);
+    ResponseEntity<MemberResponse.MemberCreateDto> createMember(MemberRequest.MemberCreateDto memberDto);
     @Operation(summary = "유저 수정")
     @ApiResponse(responseCode = "200", description = "유저 수정 성공")
     ResponseEntity<MemberResponse.MemberDto> updateMember(Long id, MemberRequest.MemberDto memberDto);

--- a/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
+++ b/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
@@ -23,7 +23,7 @@ public interface MemberApiSpec {
     ResponseEntity<MemberResponse.MemberCreateDto> createMember(MemberRequest.MemberCreateDto memberDto);
     @Operation(summary = "유저 수정")
     @ApiResponse(responseCode = "200", description = "유저 수정 성공")
-    ResponseEntity<MemberResponse.MemberDto> updateMember(Long id, MemberRequest.MemberDto memberDto);
+    ResponseEntity<MemberResponse.MemberUpdateDto> updateMember(Long id, MemberRequest.MemberDto memberDto);
     @Operation(summary = "유저 삭제")
     @ApiResponse(responseCode = "204", description = "유저 삭제 성공")
     ResponseEntity<Void> deleteMember(Long memberId);

--- a/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
+++ b/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 public interface MemberApiSpec {
     @Operation(summary = "유저 조회 및 검색")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    ResponseEntity<Page<MemberResponse.MemberDto>> getMembers(
+    ResponseEntity<Page<MemberResponse.MemberListDto>> getMembers(
             @ParameterObject MemberRequest.MemberSearchCondition searchCondition,
             Pageable pageable
     );

--- a/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
+++ b/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
@@ -30,4 +30,7 @@ public interface MemberApiSpec {
     @Operation(summary = "유저 삭제")
     @ApiResponse(responseCode = "204", description = "유저 삭제 성공")
     ResponseEntity<Void> deleteMember(Long memberId);
+    @Operation(summary = "유저 영구 삭제")
+    @ApiResponse(responseCode = "204", description = "유저 영구 삭제 성공")
+    ResponseEntity<Void> hardDeleteMember(Long memberId);
 }

--- a/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
+++ b/src/main/java/com/jk/amazon2/controller/spec/MemberApiSpec.java
@@ -12,6 +12,9 @@ import org.springframework.http.ResponseEntity;
 
 @Tag(name = "유저", description = "유저 관련 API")
 public interface MemberApiSpec {
+    @Operation(summary = "유저 단건 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    ResponseEntity<MemberResponse.MemberDetailDto> getMember(Long id);
     @Operation(summary = "유저 조회 및 검색")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     ResponseEntity<Page<MemberResponse.MemberListDto>> getMembers(

--- a/src/main/java/com/jk/amazon2/entity/Member.java
+++ b/src/main/java/com/jk/amazon2/entity/Member.java
@@ -30,4 +30,11 @@ public class Member extends BaseAudit {
         member.categoryCode = categoryCode;
         return member;
     }
+
+    public void update(String nickname, String categoryCode) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        this.categoryCode = categoryCode;
+    }
 }

--- a/src/main/java/com/jk/amazon2/entity/Member.java
+++ b/src/main/java/com/jk/amazon2/entity/Member.java
@@ -1,0 +1,33 @@
+package com.jk.amazon2.entity;
+
+import com.jk.amazon2.common.entity.BaseAudit;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+@Entity
+public class Member extends BaseAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "category_code", length = 10)
+    private String categoryCode;
+
+    @Column(name = "nickname", nullable = false, unique = true, length = 50)
+    private String nickname;
+
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = Boolean.FALSE;
+
+    public static Member of(String nickname, String categoryCode) {
+        Member member = new Member();
+        member.nickname = nickname;
+        member.categoryCode = categoryCode;
+        return member;
+    }
+}

--- a/src/main/java/com/jk/amazon2/entity/Member.java
+++ b/src/main/java/com/jk/amazon2/entity/Member.java
@@ -37,4 +37,8 @@ public class Member extends BaseAudit {
         }
         this.categoryCode = categoryCode;
     }
+
+    public void softDelete() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
+++ b/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode{
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    MEMBER_NOT_DELETED(HttpStatus.BAD_REQUEST, "소프트 삭제된 회원만 영구 삭제가 가능합니다."),
     MEMBER_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 필수 입니다."),
     MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다."),
     MEMBER_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 닉네임 입니다."),

--- a/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
+++ b/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode{
     MEMBER_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 필수 입니다."),
-    MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다.");
+    MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다."),
+    MEMBER_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 닉네임 입니다."),
+    MEMBER_CATEGORY_CODE_INVALID(HttpStatus.BAD_REQUEST, "카테고리 코드는 최대 10자까지 입력 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
+++ b/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
@@ -1,0 +1,24 @@
+package com.jk.amazon2.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode{
+    MEMBER_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 필수 입니다."),
+    MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    @Override
+    public HttpStatus status() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
+++ b/src/main/java/com/jk/amazon2/exception/MemberErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum MemberErrorCode implements ErrorCode{
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     MEMBER_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 필수 입니다."),
     MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다."),
     MEMBER_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 닉네임 입니다."),

--- a/src/main/java/com/jk/amazon2/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByNickname(String nickname);

--- a/src/main/java/com/jk/amazon2/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.jk.amazon2.repository;
+
+import com.jk.amazon2.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/jk/amazon2/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/repository/MemberRepository.java
@@ -3,10 +3,6 @@ package com.jk.amazon2.repository;
 import com.jk.amazon2.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     boolean existsByNickname(String nickname);
-
-    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/jk/amazon2/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/repository/MemberRepository.java
@@ -3,6 +3,10 @@ package com.jk.amazon2.repository;
 import com.jk.amazon2.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/jk/amazon2/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/jk/amazon2/repository/MemberRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jk.amazon2.repository;
+
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MemberRepositoryCustom {
+    Page<MemberResult.Summary> findMembers(MemberCommand.Search condition, Pageable pageable);
+}

--- a/src/main/java/com/jk/amazon2/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/jk/amazon2/repository/MemberRepositoryImpl.java
@@ -1,0 +1,74 @@
+package com.jk.amazon2.repository;
+
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.jk.amazon2.entity.QCategory.category;
+import static com.jk.amazon2.entity.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MemberResult.Summary> findMembers(MemberCommand.Search condition, Pageable pageable) {
+        List<MemberResult.Summary> content = queryFactory
+                .select(Projections.constructor(
+                        MemberResult.Summary.class,
+                        member.nickname,
+                        category.name,
+                        member.createdAt,
+                        member.deleted
+                ))
+                .from(member)
+                .leftJoin(category).on(
+                        member.categoryCode.eq(category.code),
+                        category.deleted.eq(false)
+                )
+                .where(
+                        nicknameCondition(condition.getNickname()),
+                        categoryCodeCondition(condition.getCategoryCode()),
+                        deletedCondition(condition.getDeleted())
+                )
+                .orderBy(member.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(member.count())
+                .from(member)
+                .leftJoin(category).on(
+                        member.categoryCode.eq(category.code),
+                        category.deleted.eq(false)
+                )
+                .where(
+                        nicknameCondition(condition.getNickname()),
+                        categoryCodeCondition(condition.getCategoryCode()),
+                        deletedCondition(condition.getDeleted())
+                );
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression nicknameCondition(String nickname) {
+        return nickname != null ? member.nickname.contains(nickname) : null;
+    }
+
+    private BooleanExpression categoryCodeCondition(String categoryCode) {
+        return categoryCode != null ? member.categoryCode.eq(categoryCode) : null;
+    }
+
+    private BooleanExpression deletedCondition(Boolean deleted) {
+        return deleted != null ? member.deleted.eq(deleted) : null;
+    }
+}

--- a/src/main/java/com/jk/amazon2/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/service/MemberService.java
@@ -73,4 +73,14 @@ public class MemberService {
         MemberCommand.Search command = MemberCommand.Search.from(searchCondition);
         return memberRepository.findMembers(command, pageable);
     }
+
+    @Transactional
+    public void hardDelete(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        if (!member.isDeleted()) {
+            throw new RestApiException(MemberErrorCode.MEMBER_NOT_DELETED);
+        }
+        memberRepository.delete(member);
+    }
 }

--- a/src/main/java/com/jk/amazon2/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/service/MemberService.java
@@ -55,6 +55,13 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public MemberResult.Detail findById(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        return MemberResult.Detail.from(member);
+    }
+
+    @Transactional(readOnly = true)
     public Page<MemberResult.Summary> findMembers(MemberRequest.MemberSearchCondition searchCondition, Pageable pageable) {
         MemberCommand.Search command = MemberCommand.Search.from(searchCondition);
         return memberRepository.findMembers(command, pageable);

--- a/src/main/java/com/jk/amazon2/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/service/MemberService.java
@@ -1,0 +1,39 @@
+package com.jk.amazon2.service;
+
+import com.jk.amazon2.entity.Category;
+import com.jk.amazon2.entity.Member;
+import com.jk.amazon2.exception.CategoryErrorCode;
+import com.jk.amazon2.exception.MemberErrorCode;
+import com.jk.amazon2.exception.RestApiException;
+import com.jk.amazon2.repository.CategoryRepository;
+import com.jk.amazon2.repository.MemberRepository;
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public MemberResult.Detail create(MemberCommand.Create command) {
+        if (memberRepository.existsByNickname(command.getNickname())) {
+            throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS);
+        }
+
+        Category category = categoryRepository.findByCodeAndDeletedFalse(command.getCategoryCode())
+                .orElseThrow(() -> new RestApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        Member member = Member.of(
+                command.getNickname(),
+                category.getCode()
+        );
+
+        Member savedMember = memberRepository.save(member);
+        return MemberResult.Detail.from(savedMember);
+    }
+}

--- a/src/main/java/com/jk/amazon2/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/service/MemberService.java
@@ -54,6 +54,13 @@ public class MemberService {
         return MemberResult.Update.of(member.getNickname(), member.getCategoryCode());
     }
 
+    @Transactional
+    public void delete(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        member.softDelete();
+    }
+
     @Transactional(readOnly = true)
     public MemberResult.Detail findById(Long id) {
         Member member = memberRepository.findById(id)

--- a/src/main/java/com/jk/amazon2/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.jk.amazon2.service;
 
+import com.jk.amazon2.controller.dto.MemberRequest;
 import com.jk.amazon2.entity.Category;
 import com.jk.amazon2.entity.Member;
 import com.jk.amazon2.exception.CategoryErrorCode;
@@ -10,6 +11,8 @@ import com.jk.amazon2.repository.MemberRepository;
 import com.jk.amazon2.service.dto.MemberCommand;
 import com.jk.amazon2.service.dto.MemberResult;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,5 +52,11 @@ public class MemberService {
 
         member.update(command.getNickname(), command.getCategoryCode());
         return MemberResult.Update.of(member.getNickname(), member.getCategoryCode());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<MemberResult.Summary> findMembers(MemberRequest.MemberSearchCondition searchCondition, Pageable pageable) {
+        MemberCommand.Search command = MemberCommand.Search.from(searchCondition);
+        return memberRepository.findMembers(command, pageable);
     }
 }

--- a/src/main/java/com/jk/amazon2/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/service/MemberService.java
@@ -36,4 +36,18 @@ public class MemberService {
         Member savedMember = memberRepository.save(member);
         return MemberResult.Detail.from(savedMember);
     }
+
+    @Transactional
+    public MemberResult.Update update(MemberCommand.Update command) {
+        Member member = memberRepository
+                .findByNickname(command.getNickname())
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NICKNAME_NOT_FOUND));
+
+        categoryRepository
+                .findByCodeAndDeletedFalse(command.getCategoryCode())
+                .orElseThrow(() -> new RestApiException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        member.update(command.getNickname(), command.getCategoryCode());
+        return MemberResult.Update.of(member.getNickname(), member.getCategoryCode());
+    }
 }

--- a/src/main/java/com/jk/amazon2/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/service/MemberService.java
@@ -43,8 +43,8 @@ public class MemberService {
     @Transactional
     public MemberResult.Update update(MemberCommand.Update command) {
         Member member = memberRepository
-                .findByNickname(command.getNickname())
-                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NICKNAME_NOT_FOUND));
+                .findById(command.getId())
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         categoryRepository
                 .findByCodeAndDeletedFalse(command.getCategoryCode())

--- a/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
@@ -34,4 +34,31 @@ public class MemberCommand {
             this.categoryCode = categoryCode;
         }
     }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Update {
+
+        private String nickname;
+        private String categoryCode;
+
+        public static Update of(String nickname, String categoryCode) {
+            return new Update(nickname, categoryCode);
+        }
+
+        private Update(String nickname, String categoryCode) {
+            if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
+                log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid nickname. nickname={}", nickname);
+                throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
+            }
+
+            if (categoryCode != null && (categoryCode.isBlank() || categoryCode.length() > 10)) {
+                log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid categoryCode. categoryCode={}", categoryCode);
+                throw new RestApiException(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID);
+            }
+
+            this.nickname = nickname;
+            this.categoryCode = categoryCode;
+        }
+    }
 }

--- a/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
@@ -1,0 +1,37 @@
+package com.jk.amazon2.service.dto;
+
+import com.jk.amazon2.controller.dto.MemberRequest;
+import com.jk.amazon2.exception.MemberErrorCode;
+import com.jk.amazon2.exception.RestApiException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberCommand {
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Create {
+        private String nickname;
+        private String categoryCode;
+
+        public static Create of(String nickname, String categoryCode) {
+            return new Create(nickname, categoryCode);
+        }
+
+        public static Create from(MemberRequest.MemberDto dto) {
+            return new Create(dto.nickname(), dto.categoryCode());
+        }
+
+        private Create(String nickname, String categoryCode) {
+            if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
+                log.warn("[VALIDATION_FAILED] MemberCommand.Detail - Invalid nickname. nickname={}", nickname);
+                throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
+            }
+            this.nickname = nickname;
+            this.categoryCode = categoryCode;
+        }
+    }
+}

--- a/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
@@ -6,6 +6,7 @@ import com.jk.amazon2.exception.RestApiException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -59,6 +60,24 @@ public class MemberCommand {
 
             this.nickname = nickname;
             this.categoryCode = categoryCode;
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Search {
+        private final String nickname;
+        private final String categoryCode;
+        private final Boolean deleted;
+
+        public static Search from(MemberRequest.MemberSearchCondition condition) {
+            Boolean deleted = switch (condition.status()) {
+                case "active" -> false;
+                case "deleted" -> true;
+                case null,
+                default -> null;
+            };
+            return new Search(condition.nickname(), condition.categoryCode(), deleted);
         }
     }
 }

--- a/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberCommand.java
@@ -40,14 +40,15 @@ public class MemberCommand {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Update {
 
+        private Long id;
         private String nickname;
         private String categoryCode;
 
-        public static Update of(String nickname, String categoryCode) {
-            return new Update(nickname, categoryCode);
+        public static Update of(Long id, String nickname, String categoryCode) {
+            return new Update(id, nickname, categoryCode);
         }
 
-        private Update(String nickname, String categoryCode) {
+        private Update(Long id, String nickname, String categoryCode) {
             if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid nickname. nickname={}", nickname);
                 throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
@@ -58,6 +59,7 @@ public class MemberCommand {
                 throw new RestApiException(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID);
             }
 
+            this.id = id;
             this.nickname = nickname;
             this.categoryCode = categoryCode;
         }

--- a/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
@@ -19,13 +19,15 @@ public class MemberResult {
         private String nickname;
         private String categoryCode;
         private LocalDateTime createdAt;
+        private boolean deleted;
 
         public static Detail from(Member member) {
             return new Detail(
                     member.getId(),
                     member.getNickname(),
                     member.getCategoryCode(),
-                    member.getCreatedAt()
+                    member.getCreatedAt(),
+                    member.isDeleted()
             );
         }
     }

--- a/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
@@ -38,4 +38,12 @@ public class MemberResult {
             return new Update(nickname, categoryCode);
         }
     }
+
+    public record Summary(
+            String nickname,
+            String categoryName,
+            LocalDateTime createdAt,
+            boolean deleted
+    ) {
+    }
 }

--- a/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
@@ -29,4 +29,13 @@ public class MemberResult {
             );
         }
     }
+
+    public record Update(
+            String nickname,
+            String categoryCode
+    ) {
+        public static Update of(String nickname, String categoryCode) {
+            return new Update(nickname, categoryCode);
+        }
+    }
 }

--- a/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
+++ b/src/main/java/com/jk/amazon2/service/dto/MemberResult.java
@@ -1,0 +1,32 @@
+package com.jk.amazon2.service.dto;
+
+import com.jk.amazon2.entity.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberResult {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PUBLIC, staticName = "of")
+    public static class Detail {
+        private Long id;
+        private String nickname;
+        private String categoryCode;
+        private LocalDateTime createdAt;
+
+        public static Detail from(Member member) {
+            return new Detail(
+                    member.getId(),
+                    member.getNickname(),
+                    member.getCategoryCode(),
+                    member.getCreatedAt()
+            );
+        }
+    }
+}

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -19,7 +19,8 @@ CREATE TABLE member
     updated_at    DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     updated_by    VARCHAR(50) NOT NULL,
     CONSTRAINT fk_member_category FOREIGN KEY (category_code) REFERENCES blog_category (code),
-    INDEX idx_member_deleted (deleted)
+    INDEX idx_member_deleted (deleted),
+    INDEX idx_nickname (nickname)
 );
 
 -- uk_user_week : 데이터 무결성을 위해

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
@@ -119,7 +119,7 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
 
         private static Stream<Arguments> provideUpdateMemberFailureCases() {
             return Stream.of(
-                    Arguments.of("존재하지 않는 회원", "test_member", "DESIGN", MemberErrorCode.MEMBER_NICKNAME_NOT_FOUND),
+                    Arguments.of("존재하지 않는 회원", "test_member", "DESIGN", MemberErrorCode.MEMBER_NOT_FOUND),
                     Arguments.of("닉네임 공백", "", "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
                     Arguments.of("닉네임 null", null, "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
                     Arguments.of("닉네임 50자 초과", "a".repeat(51), "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -284,6 +285,36 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
                     .andExpect(jsonPath("$.totalElements").value(2))
                     .andExpect(jsonPath("$.content[0].status").value("active"))
                     .andExpect(jsonPath("$.content[1].status").value("deleted"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 영구 삭제 - 통합 테스트")
+    class HardDeleteMember {
+        @Test
+        @DisplayName("회원 영구 삭제 성공 [success]")
+        void hardDeleteMember_success() throws Exception {
+            // given
+            Long memberId = 1L;
+
+            // when & then
+            mockMvc.perform(delete("/members/{id}/permanent", memberId))
+                    .andExpect(status().isNoContent());
+
+            verify(memberService).hardDelete(memberId);
+        }
+
+        @Test
+        @DisplayName("회원 영구 삭제 실패 - 소프트 삭제되지 않은 회원 [fail]")
+        void hardDeleteMember_fail_not_deleted() throws Exception {
+            // given
+            Long memberId = 1L;
+            org.mockito.Mockito.doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_DELETED))
+                    .when(memberService).hardDelete(memberId);
+
+            // when & then
+            mockMvc.perform(delete("/members/{id}/permanent", memberId))
+                    .andExpect(status().isBadRequest());
         }
     }
 }

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
@@ -15,15 +15,24 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -120,4 +129,161 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         }
     }
 
+    @Nested
+    @DisplayName("Member 조회 - 통합 테스트")
+    class GetMembers {
+        @DisplayName("회원 목록 조회 성공 [success]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideFilterConditions")
+        void getMembers_success(
+                String scenario,
+                String nickname,
+                String categoryCode,
+                String status,
+                int expectedCount
+        ) throws Exception {
+            // given
+            Boolean isDeleted = status == null ? null : "deleted".equals(status);
+            List<MemberResult.Summary> content = createFilteredContent(nickname, categoryCode, isDeleted, expectedCount);
+            Page<MemberResult.Summary> pageResult = new PageImpl<>(content, PageRequest.of(0, 10), expectedCount);
+
+            given(memberService.findMembers(any(MemberRequest.MemberSearchCondition.class), any(Pageable.class)))
+                    .willReturn(pageResult);
+
+            // when & then
+            var request = get("/members");
+            if (nickname != null) request.param("nickname", nickname);
+            if (categoryCode != null) request.param("categoryCode", categoryCode);
+            if (status != null) request.param("status", status);
+
+            mockMvc.perform(request)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content.length()").value(expectedCount))
+                    .andExpect(jsonPath("$.totalElements").value(expectedCount));
+
+            verify(memberService).findMembers(any(MemberRequest.MemberSearchCondition.class), any(Pageable.class));
+        }
+
+        private static Stream<Arguments> provideFilterConditions() {
+            return Stream.of(
+                    of("조건 없음",                null,  null,  null,      5),
+                    of("nickname 단일 필터",        "dev", null,  null,      3),
+                    of("categoryCode 단일 필터",    null,  "DEV", null,      3),
+                    of("active 상태 단일 필터",      null,  null,  "active",  3),
+                    of("deleted 상태 단일 필터",     null,  null,  "deleted", 2),
+                    of("nickname + categoryCode",  "dev", "DEV", null,      3),
+                    of("categoryCode + active",    null,  "DEV", "active",  2),
+                    of("nickname + active",        "dev", null,  "active",  2)
+            );
+        }
+
+        private static List<MemberResult.Summary> createFilteredContent(
+                String nickname,
+                String categoryCode,
+                Boolean isDeleted,
+                int expectedCount
+        ) {
+            List<MemberResult.Summary> allData = List.of(
+                    new MemberResult.Summary("dev_user1", "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("dev_user2", "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("design_user", "DESIGN", LocalDateTime.now(), false),
+                    new MemberResult.Summary("deleted_dev_user", "DEV", LocalDateTime.now(), true),
+                    new MemberResult.Summary("deleted_design_user", "DESIGN", LocalDateTime.now(), true)
+            );
+
+            return allData.stream()
+                    .filter(s -> nickname == null || s.nickname().contains(nickname))
+                    .filter(s -> categoryCode == null || "DEV".equals(categoryCode) && "DEV".equals(s.categoryName()))
+                    .filter(s -> isDeleted == null || s.deleted() == isDeleted)
+                    .limit(expectedCount)
+                    .toList();
+        }
+
+        @DisplayName("회원 목록 조회 성공 - 페이지네이션 [success]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("providePaginationScenarios")
+        void getMembers_success_pagination(
+                String scenario,
+                int pageNumber,
+                int pageSize,
+                int totalElements
+        ) throws Exception {
+            // given
+            List<MemberResult.Summary> content = new ArrayList<>();
+            int start = pageNumber * pageSize;
+            int end = Math.min(start + pageSize, totalElements);
+            for (int i = start; i < end; i++) {
+                content.add(new MemberResult.Summary("user" + i, "DEV", LocalDateTime.now(), false));
+            }
+
+            Pageable pageable = PageRequest.of(pageNumber, pageSize);
+            Page<MemberResult.Summary> pageResult = new PageImpl<>(content, pageable, totalElements);
+
+            given(memberService.findMembers(any(MemberRequest.MemberSearchCondition.class), any(Pageable.class)))
+                    .willReturn(pageResult);
+
+            // when & then
+            mockMvc.perform(get("/members")
+                            .param("page", String.valueOf(pageNumber))
+                            .param("size", String.valueOf(pageSize)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.totalElements").value(totalElements))
+                    .andExpect(jsonPath("$.number").value(pageNumber))
+                    .andExpect(jsonPath("$.size").value(pageSize));
+
+            verify(memberService).findMembers(any(MemberRequest.MemberSearchCondition.class), any(Pageable.class));
+        }
+
+        private static Stream<Arguments> providePaginationScenarios() {
+            return Stream.of(
+                    of("페이지 크기 10 - 첫 페이지", 0, 10, 100),
+                    of("페이지 크기 10 - 마지막 페이지", 9, 10, 100),
+                    of("페이지 크기 25 - 첫 페이지", 0, 25, 100),
+                    of("페이지 크기 25 - 마지막 페이지", 3, 25, 100),
+                    of("페이지 크기 50 - 첫 페이지", 0, 50, 100),
+                    of("페이지 크기 50 - 마지막 페이지", 1, 50, 100)
+            );
+        }
+
+        @Test
+        @DisplayName("회원 목록 조회 성공 - 빈 결과 [success]")
+        void getMembers_success_empty_result() throws Exception {
+            // given
+            Page<MemberResult.Summary> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+
+            given(memberService.findMembers(any(MemberRequest.MemberSearchCondition.class), any(Pageable.class)))
+                    .willReturn(emptyPage);
+
+            // when & then
+            mockMvc.perform(get("/members")
+                            .param("nickname", "nonexistent"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content.length()").value(0))
+                    .andExpect(jsonPath("$.totalElements").value(0));
+        }
+
+        @Test
+        @DisplayName("회원 목록 조회 성공 - status 변환 확인 [success]")
+        void getMembers_success_status_conversion() throws Exception {
+            // given
+            List<MemberResult.Summary> content = List.of(
+                    new MemberResult.Summary("dev_user1", "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("deleted_dev_user", "DEV", LocalDateTime.now(), true)
+            );
+            Page<MemberResult.Summary> pageResult = new PageImpl<>(content, PageRequest.of(0, 10), 2);
+
+            given(memberService.findMembers(any(MemberRequest.MemberSearchCondition.class), any(Pageable.class)))
+                    .willReturn(pageResult);
+
+            // when & then
+            mockMvc.perform(get("/members"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.content.length()").value(2))
+                    .andExpect(jsonPath("$.totalElements").value(2))
+                    .andExpect(jsonPath("$.content[0].status").value("active"))
+                    .andExpect(jsonPath("$.content[1].status").value("deleted"));
+        }
+    }
 }

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerIntegrationTest.java
@@ -1,0 +1,123 @@
+package com.jk.amazon2.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jk.amazon2.controller.dto.MemberRequest;
+import com.jk.amazon2.exception.MemberErrorCode;
+import com.jk.amazon2.exception.RestApiException;
+import com.jk.amazon2.service.MemberService;
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import com.jk.amazon2.testsupport.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+class MemberControllerIntegrationTest extends IntegrationTestSupport {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Nested
+    @DisplayName("Member 수정 - 통합 테스트")
+    class UpdateMember{
+        @Test
+        @DisplayName("회원 수정 성공 [success]")
+        void updateMember_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            String nickname = "updated_member";
+            String categoryCode = "DESIGN";
+
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, categoryCode);
+            MemberResult.Update updateResult = MemberResult.Update.of(nickname, categoryCode);
+
+            given(memberService.update(any(MemberCommand.Update.class)))
+                    .willReturn(updateResult);
+
+            // when & then
+            mockMvc.perform(put("/members/{id}", memberId)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.nickname").value(nickname))
+                    .andExpect(jsonPath("$.categoryCode").value(categoryCode));
+
+            verify(memberService).update(any(MemberCommand.Update.class));
+        }
+
+        @Test
+        @DisplayName("회원 수정 성공 - categoryCode null [success]")
+        void updateMember_success_with_null_categoryCode() throws Exception {
+            // given
+            Long memberId = 1L;
+            String nickname = "updated_member";
+
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null);
+            MemberResult.Update updateResult = MemberResult.Update.of(nickname, null);
+
+            given(memberService.update(any(MemberCommand.Update.class)))
+                    .willReturn(updateResult);
+
+            // when & then
+            mockMvc.perform(put("/members/{id}", memberId)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.nickname").value(nickname));
+
+            verify(memberService).update(any(MemberCommand.Update.class));
+        }
+
+        @DisplayName("회원 수정 실패 케이스 [fail]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideUpdateMemberFailureCases")
+        void updateMember_fail(String scenario, String nickname, String categoryCode, MemberErrorCode errorCode) throws Exception {
+            // given
+            Long memberId = 1L;
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, categoryCode);
+
+            given(memberService.update(any(MemberCommand.Update.class)))
+                    .willThrow(new RestApiException(errorCode));
+
+            // when & then
+            mockMvc.perform(put("/members/{id}", memberId)
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is4xxClientError());
+        }
+
+        private static Stream<Arguments> provideUpdateMemberFailureCases() {
+            return Stream.of(
+                    Arguments.of("존재하지 않는 회원", "test_member", "DESIGN", MemberErrorCode.MEMBER_NICKNAME_NOT_FOUND),
+                    Arguments.of("닉네임 공백", "", "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("닉네임 null", null, "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("닉네임 50자 초과", "a".repeat(51), "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("카테고리 코드 공백", "test_member", "", MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID),
+                    Arguments.of("카테고리 코드 10자 초과", "test_member", "a".repeat(11), MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID)
+            );
+        }
+    }
+
+}

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
@@ -1,0 +1,95 @@
+package com.jk.amazon2.controller;
+
+
+import com.jk.amazon2.controller.dto.MemberRequest;
+import com.jk.amazon2.controller.dto.MemberResponse;
+import com.jk.amazon2.exception.CategoryErrorCode;
+import com.jk.amazon2.exception.ErrorCode;
+import com.jk.amazon2.exception.MemberErrorCode;
+import com.jk.amazon2.exception.RestApiException;
+import com.jk.amazon2.service.MemberService;
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTest {
+    @Mock
+    private MemberService memberService;
+
+    private MemberController memberController;
+
+    @BeforeEach
+    void setUp() {
+        memberController = new MemberController(memberService);
+    }
+
+    @Nested
+    @DisplayName("Member 생성 - 단위 테스트")
+    class CreateMember {
+        @Test
+        @DisplayName("회원 생성 성공")
+        void createMember_success() {
+            // given
+            long id = 1L;
+            String nickname = "test_member";
+            String categoryCode = "DEV";
+
+            var request = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+
+            var savedMember = MemberResult.Detail.of(id, nickname, categoryCode, LocalDateTime.now());
+            given(memberService.create(any(MemberCommand.Create.class)))
+                    .willReturn(savedMember);
+
+            // when
+            ResponseEntity<MemberResponse.MemberCreateDto> response = memberController.createMember(request);
+        }
+
+        @DisplayName("회원 생성 실패 케이스 [fail]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideCreateMemberFailureCases")
+        void createMember_fail(String scenario, String nickname, String categoryCode, ErrorCode errorCode) {
+            // given
+            var request = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+
+            // 서비스 로직 에러인 경우에만 Mocking (유효성 검사 실패는 서비스 호출 전 발생)
+            if (errorCode == MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS || errorCode == CategoryErrorCode.CATEGORY_NOT_FOUND) {
+                given(memberService.create(any(MemberCommand.Create.class)))
+                        .willThrow(new RestApiException(errorCode));
+            }
+
+            // when & then
+            assertThatThrownBy(() -> memberController.createMember(request))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(errorCode.getMessage());
+        }
+
+        private static Stream<Arguments> provideCreateMemberFailureCases() {
+            return Stream.of(
+                    Arguments.of("닉네임 중복", "test_member", "DEV", MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS),
+                    Arguments.of("존재하지 않는 카테고리", "test_member", "NON_EXISTENT", CategoryErrorCode.CATEGORY_NOT_FOUND),
+                    Arguments.of("닉네임 공백", "", "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("닉네임 null", null, "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("닉네임 50자 초과", "a".repeat(51), "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID)
+            );
+        }
+    }
+}

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 
@@ -162,6 +163,38 @@ class MemberControllerTest {
             assertThatThrownBy(() -> memberController.getMember(id))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 영구 삭제 - 단위 테스트")
+    class HardDeleteMember {
+        @Test
+        @DisplayName("회원 영구 삭제 성공")
+        void hardDeleteMember_success() {
+            // given
+            Long id = 1L;
+
+            // when
+            ResponseEntity<Void> response = memberController.hardDeleteMember(id);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.NO_CONTENT);
+            verify(memberService).hardDelete(id);
+        }
+
+        @Test
+        @DisplayName("회원 영구 삭제 실패 - 소프트 삭제되지 않은 회원")
+        void hardDeleteMember_fail_not_deleted() {
+            // given
+            Long id = 1L;
+            doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_DELETED))
+                    .when(memberService).hardDelete(id);
+
+            // when & then
+            assertThatThrownBy(() -> memberController.hardDeleteMember(id))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_DELETED.getMessage());
         }
     }
 

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
@@ -1,6 +1,5 @@
 package com.jk.amazon2.controller;
 
-
 import com.jk.amazon2.controller.dto.MemberRequest;
 import com.jk.amazon2.controller.dto.MemberResponse;
 import com.jk.amazon2.exception.CategoryErrorCode;
@@ -92,4 +91,5 @@ class MemberControllerTest {
             );
         }
     }
+
 }

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -90,6 +91,38 @@ class MemberControllerTest {
                     Arguments.of("닉네임 null", null, "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID),
                     Arguments.of("닉네임 50자 초과", "a".repeat(51), "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID)
             );
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 삭제 - 단위 테스트")
+    class DeleteMember {
+        @Test
+        @DisplayName("회원 삭제 성공")
+        void deleteMember_success() {
+            // given
+            Long id = 1L;
+
+            // when
+            ResponseEntity<Void> response = memberController.deleteMember(id);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.NO_CONTENT);
+            verify(memberService).delete(id);
+        }
+
+        @Test
+        @DisplayName("회원 삭제 실패 - 존재하지 않는 회원")
+        void deleteMember_fail_not_found() {
+            // given
+            Long id = 999L;
+            org.mockito.Mockito.doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND))
+                    .when(memberService).delete(id);
+
+            // when & then
+            assertThatThrownBy(() -> memberController.deleteMember(id))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
     }
 

--- a/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/controller/MemberControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -54,7 +55,7 @@ class MemberControllerTest {
 
             var request = new MemberRequest.MemberCreateDto(nickname, categoryCode);
 
-            var savedMember = MemberResult.Detail.of(id, nickname, categoryCode, LocalDateTime.now());
+            var savedMember = MemberResult.Detail.of(id, nickname, categoryCode, LocalDateTime.now(), false);
             given(memberService.create(any(MemberCommand.Create.class)))
                     .willReturn(savedMember);
 
@@ -89,6 +90,45 @@ class MemberControllerTest {
                     Arguments.of("닉네임 null", null, "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID),
                     Arguments.of("닉네임 50자 초과", "a".repeat(51), "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID)
             );
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 조회 - 단위 테스트")
+    class GetMember {
+        @Test
+        @DisplayName("회원 조회 성공")
+        void getMember_success() {
+            // given
+            Long id = 1L;
+            var result = MemberResult.Detail.of(id, "test_member", "DEV", LocalDateTime.now(), false);
+            given(memberService.findById(id))
+                    .willReturn(result);
+
+            // when
+            ResponseEntity<MemberResponse.MemberDetailDto> response = memberController.getMember(id);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().id()).isEqualTo(id);
+            assertThat(response.getBody().nickname()).isEqualTo("test_member");
+            assertThat(response.getBody().categoryCode()).isEqualTo("DEV");
+            assertThat(response.getBody().status()).isEqualTo("active");
+        }
+
+        @Test
+        @DisplayName("회원 조회 실패 - 존재하지 않는 회원")
+        void getMember_fail_not_found() {
+            // given
+            Long id = 999L;
+            given(memberService.findById(id))
+                    .willThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> memberController.getMember(id))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
     }
 

--- a/src/test/java/com/jk/amazon2/integration/CategoryIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/CategoryIntegrationTest.java
@@ -5,6 +5,7 @@ import com.jk.amazon2.exception.CategoryErrorCode;
 import com.jk.amazon2.testsupport.IntegrationTestSupport;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import jakarta.persistence.EntityManager;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +31,8 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
     private MockMvc mockMvc;
     @Autowired
     private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private EntityManager entityManager;
 
     private final Faker faker = new Faker(Locale.of("ko"));
 
@@ -60,6 +63,7 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
                 .body("categoryCode", equalTo(code))
                 .body("categoryName", equalTo(name))
                 .body("description", equalTo(description));
+        entityManager.flush();
 
         // then (DB에 저장되었는지 검증)
         var sql = "SELECT name FROM blog_category WHERE code = ?";
@@ -131,6 +135,7 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
                     .body("categoryCode", equalTo(code))
                     .body("categoryName", equalTo(updateName))
                     .body("description", equalTo(updateDesc));
+            entityManager.flush();
 
             // then (DB 데이터 변경 확인)
             String selectSql = "SELECT name, description FROM blog_category WHERE code = ?";

--- a/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
 
@@ -174,14 +175,18 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         @BeforeEach
         void setUpData() {
             String categoryInsertSql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'test')";
-            jdbcTemplate.update(categoryInsertSql, "DEV_E2E", "개발", "개발팀");
-            jdbcTemplate.update(categoryInsertSql, "DESIGN_E2E", "디자인", "디자인팀");
+            jdbcTemplate.batchUpdate(categoryInsertSql, List.of(
+                    new Object[]{"DEV_E2E", "개발", "개발팀"},
+                    new Object[]{"DESIGN_E2E", "디자인", "디자인팀"}
+            ));
 
             String memberInsertSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, ?, NOW(), 'test', NOW(), 'test')";
-            jdbcTemplate.update(memberInsertSql, "dev_user1", "DEV_E2E", false);
-            jdbcTemplate.update(memberInsertSql, "dev_user2", "DEV_E2E", false);
-            jdbcTemplate.update(memberInsertSql, "design_user", "DESIGN_E2E", false);
-            jdbcTemplate.update(memberInsertSql, "deleted_user", "DEV_E2E", true);
+            jdbcTemplate.batchUpdate(memberInsertSql, List.of(
+                    new Object[]{"dev_user1", "DEV_E2E", false},
+                    new Object[]{"dev_user2", "DEV_E2E", false},
+                    new Object[]{"design_user", "DESIGN_E2E", false},
+                    new Object[]{"deleted_user", "DEV_E2E", true}
+            ));
         }
 
         @DisplayName("조회 성공 - 필터 조건별 결과 수 검증 [success]")

--- a/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class MemberIntegrationTest extends IntegrationTestSupport {
     @Autowired
@@ -163,6 +164,99 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     Arguments.of("닉네임 null", null, "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage()),
                     Arguments.of("닉네임 50자 초과", "a".repeat(51), "DEV", "닉네임은 최대 50자까지 입력 가능합니다.")
             );
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 목록 조회 통합 테스트")
+    class GetMembers {
+
+        @BeforeEach
+        void setUpData() {
+            String categoryInsertSql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'test')";
+            jdbcTemplate.update(categoryInsertSql, "DEV_E2E", "개발", "개발팀");
+            jdbcTemplate.update(categoryInsertSql, "DESIGN_E2E", "디자인", "디자인팀");
+
+            String memberInsertSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, ?, NOW(), 'test', NOW(), 'test')";
+            jdbcTemplate.update(memberInsertSql, "dev_user1", "DEV_E2E", false);
+            jdbcTemplate.update(memberInsertSql, "dev_user2", "DEV_E2E", false);
+            jdbcTemplate.update(memberInsertSql, "design_user", "DESIGN_E2E", false);
+            jdbcTemplate.update(memberInsertSql, "deleted_user", "DEV_E2E", true);
+        }
+
+        @DisplayName("조회 성공 - 필터 조건별 결과 수 검증 [success]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideFilterConditions")
+        void getMembers_success(String scenario, String nickname, String categoryCode, String status, int expectedTotal) {
+            var spec = RestAssuredMockMvc.given();
+            if (nickname != null) spec.param("nickname", nickname);
+            if (categoryCode != null) spec.param("categoryCode", categoryCode);
+            if (status != null) spec.param("status", status);
+
+            spec.when().get("/members")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("totalElements", equalTo(expectedTotal));
+        }
+
+        static Stream<Arguments> provideFilterConditions() {
+            return Stream.of(
+                    Arguments.of("전체 조회", null, null, null, 4),
+                    Arguments.of("nickname 필터", "dev", null, null, 2),
+                    Arguments.of("categoryCode 필터", null, "DEV_E2E", null, 3),
+                    Arguments.of("active 상태 필터", null, null, "active", 3),
+                    Arguments.of("deleted 상태 필터", null, null, "deleted", 1)
+            );
+        }
+
+        @Test
+        @DisplayName("조회 성공 - categoryName JOIN 반환 확인 [success]")
+        void getMembers_success_categoryName() {
+            RestAssuredMockMvc.given()
+                    .param("categoryCode", "DEV_E2E")
+                    .when().get("/members")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("content[0].categoryName", equalTo("개발"));
+        }
+
+        @Test
+        @DisplayName("조회 성공 - status 문자열 변환 확인 [success]")
+        void getMembers_success_status_conversion() {
+            RestAssuredMockMvc.given()
+                    .param("nickname", "deleted_user")
+                    .when().get("/members")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("totalElements", equalTo(1))
+                    .body("content[0].status", equalTo("deleted"));
+        }
+
+        @Test
+        @DisplayName("조회 성공 - 페이지네이션 구조 검증 [success]")
+        void getMembers_success_pagination() {
+            RestAssuredMockMvc.given()
+                    .param("page", "0")
+                    .param("size", "2")
+                    .when().get("/members")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("totalElements", equalTo(4))
+                    .body("content", hasSize(2))
+                    .body("size", equalTo(2))
+                    .body("number", equalTo(0));
+        }
+
+        @Test
+        @DisplayName("조회 성공 - 빈 결과 [success]")
+        void getMembers_success_empty() {
+            RestAssuredMockMvc.given()
+                    .param("nickname", "nonexistent_xyz")
+                    .when().get("/members")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("totalElements", equalTo(0))
+                    .body("content", hasSize(0));
         }
     }
 }

--- a/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
@@ -1,0 +1,168 @@
+package com.jk.amazon2.integration;
+
+import com.jk.amazon2.controller.dto.MemberRequest;
+import com.jk.amazon2.exception.CategoryErrorCode;
+import com.jk.amazon2.exception.MemberErrorCode;
+import com.jk.amazon2.testsupport.IntegrationTestSupport;
+import io.restassured.http.ContentType;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class MemberIntegrationTest extends IntegrationTestSupport {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final Faker faker = new Faker(Locale.of("ko"));
+
+    @BeforeEach
+    void setUp() {
+        RestAssuredMockMvc.mockMvc(mockMvc);
+    }
+
+    @Nested
+    @DisplayName("Member 생성 통합 테스트")
+    class CreateMember {
+        @DisplayName("[통합] POST /members - 생성 성공 및 DB 정합성 검증 [201 Created]")
+        @Test
+        void createMember_Integration_Success() {
+            // given
+            // 1. 카테고리 미리 생성
+            String categoryCode = "DEV_TEST";
+            String categoryName = "개발";
+            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
+            try {
+                jdbcTemplate.update(insertCategorySql, categoryCode, categoryName, "카테고리");
+            } catch (Exception e) {
+                // 이미 존재하면 무시
+            }
+
+            String nickname = faker.name().fullName();
+            // 닉네임 길이 제한(50자)에 맞게 자르기
+            if (nickname.length() > 50) nickname = nickname.substring(0, 50);
+
+            var requestDto = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+
+            // when & then (API 검증)
+            RestAssuredMockMvc
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(requestDto)
+                    .when()
+                    .post("/members")
+                    .then()
+                    .statusCode(HttpStatus.CREATED.value())
+                    .body("nickname", equalTo(nickname))
+                    .body("categoryCode", equalTo(categoryCode));
+
+            // then (DB 검증)
+            String selectSql = "SELECT count(*) FROM member WHERE nickname = ? AND category_code = ?";
+            Integer count = jdbcTemplate.queryForObject(selectSql, Integer.class, nickname, categoryCode);
+            assertThat(count).isEqualTo(1);
+        }
+
+        @DisplayName("[통합] POST /members - 중복 닉네임으로 생성 실패 [409 Conflict]")
+        @Test
+        void createMember_Integration_Fail_DuplicateNickname() {
+            // given
+            String categoryCode = "DEV_DUP";
+            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
+            try {
+                jdbcTemplate.update(insertCategorySql, categoryCode, "중복테스트용", "설명");
+            } catch (Exception e) {
+                // 이미 존재하면 무시
+            }
+
+            String nickname = "duplicate_user";
+            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
+            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+
+            var requestDto = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+
+            // when & then
+            RestAssuredMockMvc
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(requestDto)
+                    .when()
+                    .post("/members")
+                    .then()
+                    .statusCode(HttpStatus.CONFLICT.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS.name()))
+                    .body("message", equalTo(MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS.getMessage()));
+        }
+
+        @DisplayName("[통합] POST /members - 존재하지 않는 카테고리로 생성 실패 [404 Not Found]")
+        @Test
+        void createMember_Integration_Fail_CategoryNotFound() {
+            // given
+            String nickname = faker.name().fullName();
+            if (nickname.length() > 50) nickname = nickname.substring(0, 50);
+            String unknownCategoryCode = "UNKNOWN_CODE";
+
+            var requestDto = new MemberRequest.MemberCreateDto(nickname, unknownCategoryCode);
+
+            // when & then
+            RestAssuredMockMvc
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(requestDto)
+                    .when()
+                    .post("/members")
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", equalTo(CategoryErrorCode.CATEGORY_NOT_FOUND.name()))
+                    .body("message", equalTo(CategoryErrorCode.CATEGORY_NOT_FOUND.getMessage()));
+        }
+
+        @DisplayName("[통합] POST /members - 유효성 검사 실패 (닉네임) [400 Bad Request]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideInvalidMemberScenarios")
+        void createMember_Integration_Fail_Validation(
+                String scenario,
+                String nickname,
+                String categoryCode,
+                String expectedMessage
+        ) {
+            // given
+            var requestDto = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+
+            // when & then
+            RestAssuredMockMvc
+                    .given()
+                    .contentType(ContentType.JSON)
+                    .body(requestDto)
+                    .when()
+                    .post("/members")
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo(expectedMessage));
+        }
+
+        static Stream<Arguments> provideInvalidMemberScenarios() {
+            return Stream.of(
+                    Arguments.of("닉네임 공백", "", "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage()),
+                    Arguments.of("닉네임 null", null, "DEV", MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage()),
+                    Arguments.of("닉네임 50자 초과", "a".repeat(51), "DEV", "닉네임은 최대 50자까지 입력 가능합니다.")
+            );
+        }
+    }
+}

--- a/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
@@ -380,6 +380,70 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
     }
 
     @Nested
+    @DisplayName("Member 삭제 통합 테스트")
+    class DeleteMember {
+        private Long memberId;
+
+        @BeforeEach
+        void setUpData() {
+            String categorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'test')";
+            jdbcTemplate.update(categorySql, "DEL_CAT", "삭제테스트", "설명");
+
+            String memberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'test', NOW(), 'test')";
+            jdbcTemplate.update(memberSql, "delete_target_user", "DEL_CAT");
+            memberId = jdbcTemplate.queryForObject("SELECT id FROM member WHERE nickname = ?", Long.class, "delete_target_user");
+        }
+
+        @Test
+        @DisplayName("[통합] DELETE /members/{id} - 삭제 성공 및 DB 정합성 검증 [204 No Content]")
+        void deleteMember_success() {
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .delete("/members/{id}", memberId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            em.flush();
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT count(*) FROM member WHERE id = ? AND deleted = true",
+                    Integer.class, memberId
+            );
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("[통합] DELETE /members/{id} - 이미 삭제된 회원 재삭제 성공 - 멱등성 [204 No Content]")
+        void deleteMember_success_idempotent() {
+            // given
+            jdbcTemplate.update("UPDATE member SET deleted = true WHERE id = ?", memberId);
+
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .delete("/members/{id}", memberId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+        }
+
+        @Test
+        @DisplayName("[통합] DELETE /members/{id} - 존재하지 않는 회원 [404 Not Found]")
+        void deleteMember_fail_not_found() {
+            // given
+            Long nonExistentId = 999999L;
+
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .delete("/members/{id}", nonExistentId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.name()))
+                    .body("message", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
     @DisplayName("Member 단건 조회 통합 테스트")
     class GetMember {
         private Long memberId;

--- a/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
@@ -497,4 +497,73 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     .body("message", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()));
         }
     }
+
+    @Nested
+    @DisplayName("Member 영구 삭제 통합 테스트")
+    class HardDeleteMember {
+        private Long softDeletedMemberId;
+        private Long activeMemberId;
+
+        @BeforeEach
+        void setUpData() {
+            String categorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'test')";
+            jdbcTemplate.update(categorySql, "HARD_DEL", "삭제", "설명");
+
+            String memberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, ?, NOW(), 'test', NOW(), 'test')";
+            jdbcTemplate.batchUpdate(memberSql, List.of(
+                    new Object[] {"soft_deleted_member", "HARD_DEL", true},
+                    new Object[] {"active_member", "HARD_DEL", false}
+            ));
+
+            softDeletedMemberId = jdbcTemplate.queryForObject("SELECT id FROM member WHERE nickname = ?", Long.class, "soft_deleted_member");
+            activeMemberId = jdbcTemplate.queryForObject("SELECT id FROM member WHERE nickname = ?", Long.class, "active_member");
+        }
+
+        @Test
+        @DisplayName("[통합] DELETE /members/{id}/permanent - 영구 삭제 성공 [204 No Content]")
+        void hardDeleteMember_success() {
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .delete("/members/{id}/permanent", softDeletedMemberId)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            em.flush();
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT count(*) FROM member WHERE id = ?",
+                    Integer.class, softDeletedMemberId
+            );
+            assertThat(count).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("[통합] DELETE /members/{id}/permanent - 존재하지 않는 회원 [404 Not Found]")
+        void hardDeleteMember_fail_not_found() {
+            // given
+            Long nonExistentId = 999999L;
+
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .delete("/members/{id}/permanent", nonExistentId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.name()))
+                    .body("message", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("[통합] DELETE /members/{id}/permanent - 활성 회원 영구 삭제 실패 [400 Bad Request]")
+        void hardDeleteMember_fail_not_deleted() {
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .delete("/members/{id}/permanent", activeMemberId)
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_NOT_DELETED.name()))
+                    .body("message", equalTo(MemberErrorCode.MEMBER_NOT_DELETED.getMessage()));
+        }
+    }
 }

--- a/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
@@ -378,4 +378,59 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             );
         }
     }
+
+    @Nested
+    @DisplayName("Member 단건 조회 통합 테스트")
+    class GetMember {
+        private Long memberId;
+
+        @BeforeEach
+        void setUpData() {
+            String categorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'test')";
+            jdbcTemplate.update(categorySql, "GET_CAT", "조회테스트", "설명");
+
+            String memberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'test', NOW(), 'test')";
+            jdbcTemplate.update(memberSql, "get_member", "GET_CAT");
+            memberId = jdbcTemplate.queryForObject("SELECT id FROM member WHERE nickname = ?", Long.class, "get_member");
+        }
+
+        @Test
+        @DisplayName("[통합] GET /members/{id} - 조회 성공 [200 OK]")
+        void getMember_success() {
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .get("/members/{id}", memberId)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("id", equalTo(memberId.intValue()))
+                    .body("nickname", equalTo("get_member"))
+                    .body("categoryCode", equalTo("GET_CAT"))
+                    .body("status", equalTo("active"));
+
+            // DB 검증
+            em.flush();
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT count(*) FROM member WHERE id = ? AND nickname = ? AND category_code = ?",
+                    Integer.class, memberId, "get_member", "GET_CAT"
+            );
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("[통합] GET /members/{id} - 존재하지 않는 회원 [404 Not Found]")
+        void getMember_fail_not_found() {
+            // given
+            Long nonExistentId = 999999L;
+
+            // when & then
+            RestAssuredMockMvc.given()
+                    .when()
+                    .get("/members/{id}", nonExistentId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.name()))
+                    .body("message", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()));
+        }
+    }
 }

--- a/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/integration/MemberIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -32,6 +33,8 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
     private MockMvc mockMvc;
     @Autowired
     private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private EntityManager em;
 
     private final Faker faker = new Faker(Locale.of("ko"));
 
@@ -262,6 +265,117 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     .statusCode(HttpStatus.OK.value())
                     .body("totalElements", equalTo(0))
                     .body("content", hasSize(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 수정 통합 테스트")
+    class UpdateMember {
+        private Long memberId;
+
+        @BeforeEach
+        void setUpData() {
+            String categorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'test')";
+            jdbcTemplate.batchUpdate(categorySql, List.of(
+                    new Object[]{"ORIGIN_CAT", "원래카테고리", "설명"},
+                    new Object[]{"TARGET_CAT", "변경카테고리", "설명"}
+            ));
+
+            String memberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'test', NOW(), 'test')";
+            jdbcTemplate.update(memberSql, "update_target_user", "ORIGIN_CAT");
+            memberId = jdbcTemplate.queryForObject("SELECT id FROM member WHERE nickname = ?", Long.class, "update_target_user");
+        }
+
+        @Test
+        @DisplayName("[통합] PUT /members/{id} - 수정 성공 및 DB 정합성 검증 [200 OK]")
+        void updateMember_success() {
+            // given
+            String newNickname = "updated_nickname";
+            String newCategoryCode = "TARGET_CAT";
+            var request = new MemberRequest.MemberDto(newNickname, newCategoryCode);
+
+            // when && then
+            RestAssuredMockMvc.given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .put("/members/{id}", memberId)
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("nickname", equalTo(newNickname))
+                    .body("categoryCode", equalTo(newCategoryCode));
+            em.flush();
+
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT count(*) FROM member WHERE nickname = ? AND category_code = ?",
+                    Integer.class, newNickname, newCategoryCode
+            );
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("[통합] PUT /members/{id} - 존재하지 않는 회원 [404 Not Found]")
+        void updateMember_fail_member_not_found() {
+            // given
+            Long nonExistentId = 999999L;
+            var request = new MemberRequest.MemberDto("new_nickname", "ORIGIN_CAT");
+
+            // when & then
+            RestAssuredMockMvc.given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .put("/members/{id}", nonExistentId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.name()))
+                    .body("message", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("[통합] PUT /members/{id} - 존재하지 않는 카테고리 코드 [404 Not Found]")
+        void updateMember_fail_category_not_found() {
+            // given
+            var request = new MemberRequest.MemberDto("new_nickname", "NO_CAT");
+
+            // when & then
+            RestAssuredMockMvc.given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .put("/members/{id}", memberId)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", equalTo(CategoryErrorCode.CATEGORY_NOT_FOUND.name()))
+                    .body("message", equalTo(CategoryErrorCode.CATEGORY_NOT_FOUND.getMessage()));
+        }
+
+        @DisplayName("[통합] PUT /members/{id} - 유효성 검사 실패 [400 Bad Request]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideInvalidUpdateScenarios")
+        void updateMember_fail_validation(String scenario, String nickname, String categoryCode, String expectedMessage) {
+            // given
+            var request = new MemberRequest.MemberDto(nickname, categoryCode);
+
+            // when & then
+            RestAssuredMockMvc.given()
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when()
+                    .put("/members/{id}", memberId)
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("message", equalTo(expectedMessage));
+        }
+
+        static Stream<Arguments> provideInvalidUpdateScenarios() {
+            return Stream.of(
+                    Arguments.of("닉네임 공백", "", "TARGET_CAT", MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage()),
+                    Arguments.of("닉네임 null", null, "TARGET_CAT", MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage()),
+                    Arguments.of("닉네임 50자 초과", "a".repeat(51), "TARGET_CAT", MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage()),
+                    Arguments.of("카테고리 코드 공백", "new_nickname", "", MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID.getMessage()),
+                    Arguments.of("카테고리 코드 10자 초과", "new_nickname", "a".repeat(11), MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID.getMessage())
+            );
         }
     }
 }

--- a/src/test/java/com/jk/amazon2/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/jk/amazon2/repository/MemberRepositoryTest.java
@@ -1,0 +1,203 @@
+package com.jk.amazon2.repository;
+
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import com.jk.amazon2.testsupport.RepositoryTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+@DisplayName("MemberRepository 통합 테스트")
+class MemberRepositoryTest extends RepositoryTestSupport {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Nested
+    @DisplayName("findMembers 메서드 테스트")
+    class FindMembers {
+
+        @BeforeEach
+        void setUp() {
+            String categoryInsertSql = "INSERT INTO blog_category (code, name, description, created_by, deleted) VALUES (?, ?, ?, ?, ?)";
+            String memberInsertSql = "INSERT INTO member (nickname, category_code, created_by, updated_by, deleted) VALUES (?, ?, ?, ?, ?)";
+
+            jdbcTemplate.batchUpdate(categoryInsertSql, List.of(
+                    new Object[]{"DEV", "개발", "개발 팀", "test", false},
+                    new Object[]{"DESIGN", "디자인", "디자인 팀", "test", false},
+                    new Object[]{"OLD", "구팀", "삭제된 팀", "test", true}
+            ));
+
+            jdbcTemplate.batchUpdate(memberInsertSql, List.of(
+                    new Object[]{"dev_user1", "DEV", "test", "test", false},
+                    new Object[]{"dev_user2", "DEV", "test", "test", false},
+                    new Object[]{"design_user", "DESIGN", "test", "test", false},
+                    new Object[]{"deleted_user", "DEV", "test", "test", true}
+            ));
+        }
+
+        @Test
+        @DisplayName("Category와 JOIN하여 categoryName 반환 [success]")
+        void findMembers_with_join_category() {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search(null, null, null);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertThat(result.getContent())
+                    .hasSize(4)
+                    .allMatch(summary -> summary.categoryName() != null);
+        }
+
+        @Test
+        @DisplayName("null 조건이면 전체 조회 [success]")
+        void findMembers_with_null_conditions() {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search(null, null, null);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(4);
+        }
+
+        @DisplayName("nickname으로 LIKE 검색 [success]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideNicknameSearchCases")
+        void findMembers_with_nickname_filter(String scenario, String searchNickname, int expectedCount) {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search(searchNickname, null, null);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(expectedCount);
+        }
+
+        private static Stream<Arguments> provideNicknameSearchCases() {
+            return Stream.of(
+                    of("dev_user 부분 검색", "dev", 2),
+                    of("dev_user1 전체 검색", "dev_user1", 1),
+                    of("design 검색", "design", 1),
+                    of("존재하지 않는 검색", "nonexistent", 0)
+            );
+        }
+
+        @Test
+        @DisplayName("categoryCode로 정확 검색 [success]")
+        void findMembers_with_categoryCode_filter() {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search(null, "DEV", null);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(3);
+            assertThat(result.getContent())
+                    .allMatch(summary -> summary.categoryName().equals("개발"));
+        }
+
+        @DisplayName("deleted 필터 - active/deleted/null [success]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideDeletedFilterCases")
+        void findMembers_with_deleted_filter(String scenario, Boolean deletedFilter, int expectedCount) {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search(null, null, deletedFilter);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(expectedCount);
+        }
+
+        private static Stream<Arguments> provideDeletedFilterCases() {
+            return Stream.of(
+                    of("active만 조회 (deleted=false)", false, 3),
+                    of("deleted만 조회 (deleted=true)", true, 1),
+                    of("전체 조회 (deleted=null)", null, 4)
+            );
+        }
+
+        @Test
+        @DisplayName("페이지네이션 동작 확인 [success]")
+        void findMembers_pagination_and_ordering() {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search(null, null, null);
+            Pageable pageable = PageRequest.of(0, 2);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result.getNumber()).isEqualTo(0);
+                softly.assertThat(result.getSize()).isEqualTo(2);
+                softly.assertThat(result.getTotalElements()).isEqualTo(4);
+                softly.assertThat(result.getTotalPages()).isEqualTo(2);
+                softly.assertThat(result.getContent()).hasSize(2);
+            });
+        }
+
+        @Test
+        @DisplayName("createdAt DESC 정렬 확인 [success]")
+        void findMembers_ordering_by_createdAt() {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search(null, null, null);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertThat(result.getContent())
+                    .isSortedAccordingTo((s1, s2) -> s2.createdAt().compareTo(s1.createdAt()));
+        }
+
+        @Test
+        @DisplayName("복합 검색 조건 - nickname + categoryCode [success]")
+        void findMembers_with_combined_filters() {
+            // given
+            MemberCommand.Search command = new MemberCommand.Search("dev", "DEV", null);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<MemberResult.Summary> result = memberRepository.findMembers(command, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            assertThat(result.getContent())
+                    .allMatch(summary ->
+                        summary.nickname().contains("dev") && summary.categoryName().equals("개발")
+                    );
+        }
+    }
+}

--- a/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
@@ -125,4 +125,45 @@ class MemberServiceTest {
                     .hasMessage(MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS.getMessage());
         }
     }
+
+    @Nested
+    @DisplayName("Member 조회 - 단위 테스트")
+    class GetMember {
+        @Test
+        @DisplayName("회원 조회 성공 [success]")
+        void findById_success() {
+            // given
+            Long id = 1L;
+            Member member = Member.of("test_member", "DEV");
+            ReflectionTestUtils.setField(member, "id", id);
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.of(member));
+
+            // when
+            MemberResult.Detail result = memberService.findById(id);
+
+            // then
+            assertThat(result).isNotNull();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.getId()).isEqualTo(id);
+                softly.assertThat(result.getNickname()).isEqualTo("test_member");
+                softly.assertThat(result.getCategoryCode()).isEqualTo("DEV");
+                softly.assertThat(result.isDeleted()).isFalse();
+            });
+        }
+
+        @Test
+        @DisplayName("회원 조회 실패 - 존재하지 않는 회원 [fail]")
+        void findById_fail_not_found() {
+            // given
+            Long id = 999L;
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.findById(id))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
@@ -1,0 +1,128 @@
+package com.jk.amazon2.service;
+
+import com.jk.amazon2.entity.Category;
+import com.jk.amazon2.entity.Member;
+import com.jk.amazon2.exception.CategoryErrorCode;
+import com.jk.amazon2.exception.MemberErrorCode;
+import com.jk.amazon2.exception.RestApiException;
+import com.jk.amazon2.repository.CategoryRepository;
+import com.jk.amazon2.repository.MemberRepository;
+import com.jk.amazon2.service.dto.MemberCommand;
+import com.jk.amazon2.service.dto.MemberResult;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        memberService = new MemberService(memberRepository, categoryRepository);
+
+    }
+
+    @Nested
+    @DisplayName("Member 생성 - 단위 테스트")
+    class CreateMember {
+        @DisplayName("유저 생성 시, 일력된 정보가 엔티티로 변환되어 저장 [success]")
+        @Test
+        void member_create_success() {
+            // given
+            Long id = 1L;
+            String nickname = "test";
+            String categoryCode = "TEST";
+            Category category = Category.of(categoryCode, "테스트카테고리", "설명");
+
+            var inputMember = MemberCommand.Create.of(nickname, categoryCode);
+
+            given(categoryRepository.findByCodeAndDeletedFalse(categoryCode))
+                    .willReturn(Optional.of(category));
+            given(memberRepository.existsByNickname(any(String.class)))
+                    .willReturn(false);
+            given(memberRepository.save(any(Member.class)))
+                    .willAnswer(invocation -> {
+                        Member memberToSave = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(memberToSave, "id", id);
+                        return memberToSave;
+                    });
+
+            // when
+            MemberResult.Detail savedMember = memberService.create(inputMember);
+            ReflectionTestUtils.setField(savedMember, "id", id);
+
+            // then
+            assertThat(savedMember).isNotNull();
+            SoftAssertions.assertSoftly(softly ->{
+                softly.assertThat(savedMember.getNickname()).isEqualTo(nickname);
+                softly.assertThat(savedMember.getCategoryCode()).isEqualTo(categoryCode);
+                softly.assertThat(savedMember.getId()).isEqualTo(id);
+            });
+
+            // Verify Service Call
+            ArgumentCaptor<Member> commandCaptor = ArgumentCaptor.forClass(Member.class);
+            verify(memberRepository).save(commandCaptor.capture());
+            Member capturedCommand = commandCaptor.getValue();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(capturedCommand.getId()).as("유저의 id 검증").isEqualTo(id);
+                softly.assertThat(capturedCommand.getNickname()).as("유저명 검증").isEqualTo(nickname);
+                softly.assertThat(capturedCommand.getCategoryCode()).as("카테고리 코드 검증").isEqualTo(categoryCode);
+            });
+        }
+
+        @DisplayName("유저 생성 시, 존재하지 않는 카테고리 코드를 입력하면 실패 [fail]")
+        @Test
+        void member_create_fail_category_not_found() {
+            // given
+            String nickname = "test";
+            String categoryCode = "NON_EXISTENT_CODE";
+            var inputMember = MemberCommand.Create.of(nickname, categoryCode);
+
+            given(categoryRepository.findByCodeAndDeletedFalse(categoryCode)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.create(inputMember))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessage(CategoryErrorCode.CATEGORY_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("유저 생성 시, 이미 존재하는 닉네임이면 실패 [fail]")
+        @Test
+        void member_create_fail_nickname_duplicate() {
+            // given
+            String nickname = "duplicate_user";
+            String categoryCode = "TEST";
+
+            var inputMember = MemberCommand.Create.of(nickname, categoryCode);
+
+            given(memberRepository.existsByNickname(any(String.class)))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> memberService.create(inputMember))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessage(MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
@@ -127,6 +127,59 @@ class MemberServiceTest {
     }
 
     @Nested
+    @DisplayName("Member 삭제 - 단위 테스트")
+    class DeleteMember {
+        @Test
+        @DisplayName("회원 삭제 성공 [success]")
+        void delete_success() {
+            // given
+            Long id = 1L;
+            Member member = Member.of("test_member", "DEV");
+            ReflectionTestUtils.setField(member, "id", id);
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.of(member));
+
+            // when
+            memberService.delete(id);
+
+            // then
+            assertThat(member.isDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 회원 재삭제 성공 - 멱등성 [success]")
+        void delete_success_already_deleted() {
+            // given
+            Long id = 1L;
+            Member member = Member.of("test_member", "DEV");
+            ReflectionTestUtils.setField(member, "id", id);
+            member.softDelete();
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.of(member));
+
+            // when
+            memberService.delete(id);
+
+            // then
+            assertThat(member.isDeleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("회원 삭제 실패 - 존재하지 않는 회원 [fail]")
+        void delete_fail_not_found() {
+            // given
+            Long id = 999L;
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.delete(id))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
     @DisplayName("Member 조회 - 단위 테스트")
     class GetMember {
         @Test

--- a/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/service/MemberServiceTest.java
@@ -219,4 +219,56 @@ class MemberServiceTest {
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
     }
+
+    @Nested
+    @DisplayName("Member 영구 삭제 - 단위 테스트")
+    class HardDeleteMember {
+        @Test
+        @DisplayName("회원 영구 삭제 성공 [success]")
+        void hardDelete_success() {
+            // given
+            Long id = 1L;
+            Member member = Member.of("test_member", "DEV");
+            ReflectionTestUtils.setField(member, "id", id);
+            member.softDelete();
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.of(member));
+
+            // when
+            memberService.hardDelete(id);
+
+            // then
+            verify(memberRepository).delete(member);
+        }
+
+        @Test
+        @DisplayName("회원 영구 삭제 실패 - 존재하지 않는 회원 [fail]")
+        void hardDelete_fail_not_found() {
+            // given
+            Long id = 999L;
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.hardDelete(id))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("회원 영구 삭제 실패 - 소프트 삭제되지 않은 회원 [fail]")
+        void hardDelete_fail_not_deleted() {
+            // given
+            Long id = 1L;
+            Member member = Member.of("test_member", "DEV");
+            ReflectionTestUtils.setField(member, "id", id);
+            given(memberRepository.findById(id))
+                    .willReturn(Optional.of(member));
+
+            // when & then
+            assertThatThrownBy(() -> memberService.hardDelete(id))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_DELETED.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
@@ -1,5 +1,6 @@
 package com.jk.amazon2.service.dto;
 
+import com.jk.amazon2.controller.dto.MemberRequest;
 import com.jk.amazon2.exception.MemberErrorCode;
 import com.jk.amazon2.exception.RestApiException;
 import org.junit.jupiter.api.DisplayName;
@@ -135,6 +136,36 @@ class MemberCommandTest {
                     of("categoryCode가 빈 문자열인 경우", "tester", ""),
                     of("categoryCode가 공백인 경우", "tester", "   "),
                     of("categoryCode가 10자를 초과하는 경우", "tester", "a".repeat(11))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("MemberCommand.Search 테스트")
+    class MemberCommand_Search {
+        @DisplayName("status를 deleted boolean으로 변환 [success]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideStatusConversions")
+        void search_from_with_status_conversion(
+                String scenario,
+                String inputStatus,
+                Boolean expectedDeleted
+        ) {
+            // given
+            var condition = new MemberRequest.MemberSearchCondition(null, null, inputStatus);
+
+            // when
+            MemberCommand.Search command = MemberCommand.Search.from(condition);
+
+            // then
+            assertThat(command.getDeleted()).isEqualTo(expectedDeleted);
+        }
+
+        private static Stream<Arguments> provideStatusConversions() {
+            return Stream.of(
+                    of("active 상태 변환", "active", false),
+                    of("deleted 상태 변환", "deleted", true),
+                    of("상태 지정 없음", null, null)
             );
         }
     }

--- a/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
@@ -3,6 +3,7 @@ package com.jk.amazon2.service.dto;
 import com.jk.amazon2.exception.MemberErrorCode;
 import com.jk.amazon2.exception.RestApiException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,48 +13,129 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.params.provider.Arguments.of;
 
 @ExtendWith(MockitoExtension.class)
 class MemberCommandTest {
+    @Nested
+    @DisplayName("MemberCommand.Create 테스트")
+    class MemberCommand_Create {
+        @Test
+        @DisplayName("MemberCommand.Create 생성 성공 [success]")
+        void create_success() {
+            // given
+            String nickname = "tester";
+            String categoryCode = "DEV";
 
-    @Test
-    @DisplayName("MemberCommand.Create 생성 성공 [success]")
-    void create_success() {
-        // given
-        String nickname = "tester";
-        String categoryCode = "DEV";
+            // when
+            MemberCommand.Create command = MemberCommand.Create.of(nickname, categoryCode);
 
-        // when
-        MemberCommand.Create command = MemberCommand.Create.of(nickname, categoryCode);
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(command.getNickname()).isEqualTo(nickname);
+                softly.assertThat(command.getCategoryCode()).isEqualTo(categoryCode);
+            });
+        }
 
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(command.getNickname()).isEqualTo(nickname);
-            softly.assertThat(command.getCategoryCode()).isEqualTo(categoryCode);
-        });
+        @DisplayName("닉네임 유효성 검사 실패 케이스 [fail]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideInvalidNicknames")
+        void create_fail_invalid_nickname(
+                String scenario,
+                String invalidNickname
+        ) {
+            // when & then
+            assertThatThrownBy(() -> MemberCommand.Create.of(invalidNickname, "DEV"))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
+        }
+
+        private static Stream<Arguments> provideInvalidNicknames() {
+            return Stream.of(
+                    of("nickname이 null인 경우", null),
+                    of("nickname이 빈 문자열인 경우", ""),
+                    of("nickname이 공백인 경우", "   "),
+                    of("nickname이 50자를 초과하는 경우", "a".repeat(51))
+            );
+        }
     }
 
-    @DisplayName("닉네임 유효성 검사 실패 케이스 [fail]")
-    @ParameterizedTest(name = "[{index}] {0}")
-    @MethodSource("provideInvalidNicknames")
-    void create_fail_invalid_nickname(
-            String scenario,
-            String invalidNickname
-    ) {
-        // when & then
-        assertThatThrownBy(() -> MemberCommand.Create.of(invalidNickname, "DEV"))
-                .isInstanceOf(RestApiException.class)
-                .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
-    }
+    @Nested
+    @DisplayName("MemberCommand.Update 테스트")
+    class MemberCommand_Update {
+        @DisplayName("MemberCommand.Update 생성 성공 케이스 [success]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideValidUpdateCommands")
+        void update_success(
+                String scenario,
+                String nickname,
+                String categoryCode
+        ) {
+            // when
+            MemberCommand.Update command = MemberCommand.Update.of(nickname, categoryCode);
 
-    private static Stream<Arguments> provideInvalidNicknames() {
-        return Stream.of(
-                Arguments.of("nickname이 null인 경우", null),
-                Arguments.of("nickname이 빈 문자열인 경우", ""),
-                Arguments.of("nickname이 공백인 경우", "   "),
-                Arguments.of("nickname이 50자를 초과하는 경우", "a".repeat(51))
-        );
+            // then
+            assertThat(command).isNotNull();
+            assertSoftly(softly -> {
+                softly.assertThat(command.getNickname()).isEqualTo(nickname);
+                softly.assertThat(command.getCategoryCode()).isEqualTo(categoryCode);
+            });
+        }
+
+        private static Stream<Arguments> provideValidUpdateCommands() {
+            return Stream.of(
+                    of("기본 성공", "updatedNickname", "DESIGN"),
+                    of("categoryCode null", "updatedNickname", null),
+                    of("categoryCode 10자", "updatedNickname", "a".repeat(10))
+            );
+        }
+
+        @DisplayName("닉네임 유효성 검사 실패 케이스 [fail]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideInvalidUpdateNicknames")
+        void update_fail_invalid_nickname(
+                String scenario,
+                String invalidNickname,
+                String categoryCode
+        ) {
+            // when & then
+            assertThatThrownBy(() -> MemberCommand.Update.of(invalidNickname, categoryCode))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
+        }
+
+        private static Stream<Arguments> provideInvalidUpdateNicknames() {
+            return Stream.of(
+                    of("nickname이 null인 경우", null, "DESIGN"),
+                    of("nickname이 빈 문자열인 경우", "", "DESIGN"),
+                    of("nickname이 공백인 경우", "   ", "DESIGN"),
+                    of("nickname이 50자를 초과하는 경우", "a".repeat(51), "DESIGN")
+            );
+        }
+
+        @DisplayName("카테고리 코드 유효성 검사 실패 케이스 [fail]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideInvalidUpdateCategoryCodes")
+        void update_fail_invalid_categoryCode(
+                String scenario,
+                String nickname,
+                String invalidCategoryCode
+        ) {
+            // when & then
+            assertThatThrownBy(() -> MemberCommand.Update.of(nickname, invalidCategoryCode))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID.getMessage());
+        }
+
+        private static Stream<Arguments> provideInvalidUpdateCategoryCodes() {
+            return Stream.of(
+                    of("categoryCode가 빈 문자열인 경우", "tester", ""),
+                    of("categoryCode가 공백인 경우", "tester", "   "),
+                    of("categoryCode가 10자를 초과하는 경우", "tester", "a".repeat(11))
+            );
+        }
     }
 }

--- a/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
@@ -76,7 +76,7 @@ class MemberCommandTest {
                 String categoryCode
         ) {
             // when
-            MemberCommand.Update command = MemberCommand.Update.of(nickname, categoryCode);
+            MemberCommand.Update command = MemberCommand.Update.of(1L, nickname, categoryCode);
 
             // then
             assertThat(command).isNotNull();
@@ -103,7 +103,7 @@ class MemberCommandTest {
                 String categoryCode
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of(invalidNickname, categoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of(1L, invalidNickname, categoryCode))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
         }
@@ -126,7 +126,7 @@ class MemberCommandTest {
                 String invalidCategoryCode
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of(nickname, invalidCategoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of(1L, nickname, invalidCategoryCode))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID.getMessage());
         }

--- a/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/service/dto/MemberCommandTest.java
@@ -1,0 +1,59 @@
+package com.jk.amazon2.service.dto;
+
+import com.jk.amazon2.exception.MemberErrorCode;
+import com.jk.amazon2.exception.RestApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@ExtendWith(MockitoExtension.class)
+class MemberCommandTest {
+
+    @Test
+    @DisplayName("MemberCommand.Create 생성 성공 [success]")
+    void create_success() {
+        // given
+        String nickname = "tester";
+        String categoryCode = "DEV";
+
+        // when
+        MemberCommand.Create command = MemberCommand.Create.of(nickname, categoryCode);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(command.getNickname()).isEqualTo(nickname);
+            softly.assertThat(command.getCategoryCode()).isEqualTo(categoryCode);
+        });
+    }
+
+    @DisplayName("닉네임 유효성 검사 실패 케이스 [fail]")
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("provideInvalidNicknames")
+    void create_fail_invalid_nickname(
+            String scenario,
+            String invalidNickname
+    ) {
+        // when & then
+        assertThatThrownBy(() -> MemberCommand.Create.of(invalidNickname, "DEV"))
+                .isInstanceOf(RestApiException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
+    }
+
+    private static Stream<Arguments> provideInvalidNicknames() {
+        return Stream.of(
+                Arguments.of("nickname이 null인 경우", null),
+                Arguments.of("nickname이 빈 문자열인 경우", ""),
+                Arguments.of("nickname이 공백인 경우", "   "),
+                Arguments.of("nickname이 50자를 초과하는 경우", "a".repeat(51))
+        );
+    }
+}

--- a/src/test/java/com/jk/amazon2/testsupport/IntegrationTestSupport.java
+++ b/src/test/java/com/jk/amazon2/testsupport/IntegrationTestSupport.java
@@ -5,8 +5,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @Tag("integration")
+@Transactional
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @Import({TestContainerConfig.class, TestJacksonConfig.class})

--- a/src/test/java/com/jk/amazon2/testsupport/IntegrationTestSupport.java
+++ b/src/test/java/com/jk/amazon2/testsupport/IntegrationTestSupport.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 @Tag("integration")
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@Import(TestContainerConfig.class)
+@Import({TestContainerConfig.class, TestJacksonConfig.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 public abstract class IntegrationTestSupport {
 }

--- a/src/test/java/com/jk/amazon2/testsupport/QueryDslTestConfig.java
+++ b/src/test/java/com/jk/amazon2/testsupport/QueryDslTestConfig.java
@@ -1,0 +1,14 @@
+package com.jk.amazon2.testsupport;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class QueryDslTestConfig {
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/com/jk/amazon2/testsupport/RepositoryTestSupport.java
+++ b/src/test/java/com/jk/amazon2/testsupport/RepositoryTestSupport.java
@@ -1,0 +1,17 @@
+package com.jk.amazon2.testsupport;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Tag("integration")
+@ActiveProfiles("test")
+@Import({TestContainerConfig.class, QueryDslTestConfig.class})
+@DataJpaTest
+@AutoConfigureTestDatabase(replace =  AutoConfigureTestDatabase.Replace.NONE)
+public class RepositoryTestSupport {
+}
+
+

--- a/src/test/java/com/jk/amazon2/testsupport/TestJacksonConfig.java
+++ b/src/test/java/com/jk/amazon2/testsupport/TestJacksonConfig.java
@@ -1,0 +1,13 @@
+package com.jk.amazon2.testsupport;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestJacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}


### PR DESCRIPTION
## 개요
관리자 페이지를 위한 회원 CRUD API 를 구현

## 변경사항
- `POST /members` - 회원 생성
- `GET /members` - 회원 목록 조회 (닉네임/카테고리/상태 필터, 페이지네이션)                                                                                                                                                      
- `GET /members/{id}` - 회원 단건 조회
- `PUT /members/{id}` - 회원 정보 수정                                                                                                                                                                                           
- `DELETE /members/{id}` - 회원 소프트 삭제 (멱등성 보장)
- `DELETE /members/{id}/permanent` - 소프트 삭제된 회원 영구 삭제 

## 테스트 방법
- 각 API 별 단위 / 통합 / E2E 테스트 
- `./gradlew test` 전체 테스트 통과 확인

## 관련 이슈
Closes #3