### PR TITLE
#22: BatchService 트랜잭션 경계 분리 및 테스트 개선

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/service/BatchService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/BatchService.java
@@ -3,13 +3,7 @@ package com.jk.amazon2.posting.service;
 import com.jk.amazon2.member.entity.Member;
 import com.jk.amazon2.member.repository.MemberRepository;
 import com.jk.amazon2.posting.entity.BatchExecution;
-import com.jk.amazon2.posting.entity.Posting;
-import com.jk.amazon2.posting.entity.PostingError;
-import com.jk.amazon2.posting.exception.ParsingException;
-import com.jk.amazon2.posting.exception.ScrapingException;
 import com.jk.amazon2.posting.repository.BatchExecutionRepository;
-import com.jk.amazon2.posting.repository.PostingErrorRepository;
-import com.jk.amazon2.posting.repository.PostingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,20 +23,16 @@ public class BatchService {
 
     private final BatchExecutionRepository batchExecutionRepository;
     private final MemberRepository memberRepository;
-    private final PostingService postingService;
-    private final PostingErrorRepository postingErrorRepository;
-    private final ErrorHandler errorHandler;
     private final NaverBlogScraper scraper;
     private final RateLimiter rateLimiter;
-    private final PostingRepository postingRepository;
+    private final BatchTaskProcessor batchTaskProcessor;
 
-    @Transactional
+    // @Transactional 제거 - async 스레드와 트랜잭션 경계를 분리
     public Long executeBatch(LocalDate startDate, LocalDate endDate, String batchType) {
-        BatchExecution execution = new BatchExecution(batchType, startDate, endDate);
-        batchExecutionRepository.save(execution);
+        BatchExecution execution = createExecution(batchType, startDate, endDate);
 
         log.info("[BATCH] Posting batch started - type={}, period={}~{}",
-            batchType, startDate, endDate);
+                batchType, startDate, endDate);
 
         BlockingQueue<PostingTask> queue = new LinkedBlockingQueue<>(QUEUE_CAPACITY);
         ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -51,27 +41,22 @@ public class BatchService {
             List<Member> members = memberRepository.findAll();
             prepareQueue(queue, members, startDate, endDate);
 
-            executor.submit(() -> processQueue(queue, execution));
+            Future<?> future = executor.submit(() -> processQueue(queue, execution));
+            future.get(); // 스레드 완전 종료 보장
 
-            try {
-                waitForQueueEmpty(queue);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                log.warn("[BATCH] Queue wait interrupted", e);
-            }
-
-            execution.complete();
-            batchExecutionRepository.save(execution);
+            completeExecution(execution);
 
             log.info("[BATCH] Posting batch completed - total={}, success={}, retry={}, failed={}",
-                execution.getTotalCount(), execution.getSuccessCount(),
-                execution.getRetryCount(), execution.getFailedCount());
+                    execution.getTotalCount(), execution.getSuccessCount(),
+                    execution.getRetryCount(), execution.getFailedCount());
 
-        } catch (Exception e) {
-            execution.fail();
-            batchExecutionRepository.save(execution);
-            log.error("[BATCH] Batch failed", e);
-            throw e;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            failExecution(execution);
+            log.error("[BATCH] Batch interrupted", e);
+        } catch (ExecutionException e) {
+            failExecution(execution);
+            log.error("[BATCH] Batch failed", e.getCause());
         } finally {
             executor.shutdown();
         }
@@ -79,26 +64,35 @@ public class BatchService {
         return execution.getId();
     }
 
+    @Transactional
+    public BatchExecution createExecution(String batchType, LocalDate startDate, LocalDate endDate) {
+        BatchExecution execution = new BatchExecution(batchType, startDate, endDate);
+        return batchExecutionRepository.save(execution);
+    }
+
+    @Transactional
+    public void completeExecution(BatchExecution execution) {
+        execution.complete();
+        batchExecutionRepository.save(execution);
+    }
+
+    @Transactional
+    public void failExecution(BatchExecution execution) {
+        execution.fail();
+        batchExecutionRepository.save(execution);
+    }
+
     private void prepareQueue(BlockingQueue<PostingTask> queue, List<Member> members,
-                             LocalDate startDate, LocalDate endDate) {
+                              LocalDate startDate, LocalDate endDate) {
         for (Member member : members) {
             LocalDate current = startDate;
             while (!current.isAfter(endDate)) {
-                String dayOfWeek = getDayOfWeekKr(current);
-                PostingTask task = new PostingTask(
-                    member.getId(),
-                    member.getNickname(),
-                    current,
-                    dayOfWeek
-                );
-
                 try {
-                    queue.put(task);
+                    queue.put(new PostingTask(member.getId(), member.getNickname(), current, getDayOfWeekKr(current)));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     log.error("Queue interrupted while preparing", e);
                 }
-
                 current = current.plusDays(1);
             }
         }
@@ -106,7 +100,6 @@ public class BatchService {
 
     private void processQueue(BlockingQueue<PostingTask> queue, BatchExecution execution) {
         PostingTask task;
-
         while ((task = queue.poll()) != null || !queue.isEmpty()) {
             if (task == null) {
                 try {
@@ -117,89 +110,9 @@ public class BatchService {
                 }
                 continue;
             }
-
             rateLimiter.acquire();
-            processTask(task, queue, execution);
+            batchTaskProcessor.processTask(task, queue, execution);
         }
-    }
-
-    private void processTask(PostingTask task, BlockingQueue<PostingTask> queue,
-                            BatchExecution execution) {
-        try {
-            Integer count = scraper.scrapePostingCount(task.memberId.toString(), task.targetDate);
-
-            LocalDate weekStart = getWeekStartDate(task.targetDate);
-            updatePostingForDay(task.memberId, weekStart, task.dayOfWeek, count);
-
-            execution.incrementSuccessCount();
-            batchExecutionRepository.save(execution);
-
-            log.info("[BATCH] Saved posting - member={}, week={}, day={}, count={}",
-                task.memberId, weekStart, task.dayOfWeek, count);
-
-        } catch (ParsingException | ScrapingException e) {
-            handleTaskError(task, queue, execution, e);
-        }
-    }
-
-    private void handleTaskError(PostingTask task, BlockingQueue<PostingTask> queue,
-                                BatchExecution execution, Exception e) {
-        errorHandler.handleError(task.memberId, task.targetDate, task.dayOfWeek, e);
-
-        PostingError error = postingErrorRepository
-            .findByMemberAndDate(task.memberId, task.targetDate)
-            .stream()
-            .filter(err -> err.getDayOfWeek().equals(task.dayOfWeek))
-            .findFirst()
-            .orElse(null);
-
-        if (error != null && error.getRetryCount() < 3) {
-            execution.incrementRetryCount();
-            try {
-                queue.put(task);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-            }
-        } else if (error != null) {
-            execution.incrementFailedCount();
-            errorHandler.handleRetry(error);
-        }
-
-        batchExecutionRepository.save(execution);
-        log.warn("[BATCH] Failed member={}, date={}, error={}",
-            task.memberId, task.targetDate, e.getMessage());
-    }
-
-    private void updatePostingForDay(Long memberId, LocalDate weekStart,
-                                    String dayOfWeek, Integer count) {
-        Posting existing = postingRepository.findByMemberIdAndWeekStartDateWithLock(memberId, weekStart)
-            .orElseGet(() -> createNewPosting(memberId, weekStart));
-
-        switch (dayOfWeek) {
-            case "mon" -> existing.setMon(count);
-            case "tue" -> existing.setTue(count);
-            case "wed" -> existing.setWed(count);
-            case "thu" -> existing.setThu(count);
-            case "fri" -> existing.setFri(count);
-            case "sat" -> existing.setSat(count);
-            case "sun" -> existing.setSun(count);
-        }
-
-        postingService.savePosting(memberId, weekStart,
-            existing.getMon(), existing.getTue(), existing.getWed(),
-            existing.getThu(), existing.getFri(), existing.getSat(),
-            existing.getSun(), "batch");
-    }
-
-    private Posting createNewPosting(Long memberId, LocalDate weekStart) {
-        return new Posting(memberId, weekStart, 0, 0, 0, 0, 0, 0, 0, "batch");
-    }
-
-    private LocalDate getWeekStartDate(LocalDate date) {
-        while (date.getDayOfWeek() != DayOfWeek.MONDAY) {
-            date = date.minusDays(1);
-        }
-        return date;
     }
 
     private String getDayOfWeekKr(LocalDate date) {
@@ -214,11 +127,5 @@ public class BatchService {
         };
     }
 
-    private void waitForQueueEmpty(BlockingQueue<PostingTask> queue) throws InterruptedException {
-        while (!queue.isEmpty()) {
-            Thread.sleep(100);
-        }
-    }
-
-    record PostingTask(Long memberId, String memberNickname, LocalDate targetDate, String dayOfWeek) {}
+    public record PostingTask(Long memberId, String memberNickname, LocalDate targetDate, String dayOfWeek) {}
 }

--- a/src/main/java/com/jk/amazon2/posting/service/BatchTaskProcessor.java
+++ b/src/main/java/com/jk/amazon2/posting/service/BatchTaskProcessor.java
@@ -1,0 +1,107 @@
+package com.jk.amazon2.posting.service;
+
+import com.jk.amazon2.posting.entity.BatchExecution;
+import com.jk.amazon2.posting.entity.Posting;
+import com.jk.amazon2.posting.entity.PostingError;
+import com.jk.amazon2.posting.exception.ParsingException;
+import com.jk.amazon2.posting.exception.ScrapingException;
+import com.jk.amazon2.posting.repository.BatchExecutionRepository;
+import com.jk.amazon2.posting.repository.PostingErrorRepository;
+import com.jk.amazon2.posting.repository.PostingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.concurrent.BlockingQueue;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BatchTaskProcessor {
+
+    private final BatchExecutionRepository batchExecutionRepository;
+    private final PostingService postingService;
+    private final PostingErrorRepository postingErrorRepository;
+    private final ErrorHandler errorHandler;
+    private final NaverBlogScraper scraper;
+    private final PostingRepository postingRepository;
+
+    @Transactional
+    public void processTask(BatchService.PostingTask task, BlockingQueue<BatchService.PostingTask> queue, BatchExecution execution) {
+        try {
+            Integer count = scraper.scrapePostingCount(task.memberId().toString(), task.targetDate());
+            LocalDate weekStart = getWeekStartDate(task.targetDate());
+            updatePostingForDay(task.memberId(), weekStart, task.dayOfWeek(), count);
+
+            execution.incrementSuccessCount();
+            batchExecutionRepository.save(execution);
+
+            log.info("[BATCH] Saved posting - member={}, week={}, day={}, count={}",
+                    task.memberId(), weekStart, task.dayOfWeek(), count);
+
+        } catch (ParsingException | ScrapingException e) {
+            handleTaskError(task, queue, execution, e);
+        }
+    }
+
+    private void handleTaskError(BatchService.PostingTask task, BlockingQueue<BatchService.PostingTask> queue,
+                                 BatchExecution execution, Exception e) {
+        errorHandler.handleError(task.memberId(), task.targetDate(), task.dayOfWeek(), e);
+
+        PostingError error = postingErrorRepository
+                .findByMemberAndDate(task.memberId(), task.targetDate())
+                .stream()
+                .filter(err -> err.getDayOfWeek().equals(task.dayOfWeek()))
+                .findFirst()
+                .orElse(null);
+
+        if (error != null && error.getRetryCount() < 3) {
+            execution.incrementRetryCount();
+            try {
+                queue.put(task);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        } else if (error != null) {
+            execution.incrementFailedCount();
+            errorHandler.handleRetry(error);
+        }
+
+        batchExecutionRepository.save(execution);
+        log.warn("[BATCH] Failed member={}, date={}, error={}", task.memberId(), task.targetDate(), e.getMessage());
+    }
+
+    private void updatePostingForDay(Long memberId, LocalDate weekStart, String dayOfWeek, Integer count) {
+        Posting existing = postingRepository.findByMemberIdAndWeekStartDateWithLock(memberId, weekStart)
+                .orElseGet(() -> createNewPosting(memberId, weekStart));
+
+        switch (dayOfWeek) {
+            case "mon" -> existing.setMon(count);
+            case "tue" -> existing.setTue(count);
+            case "wed" -> existing.setWed(count);
+            case "thu" -> existing.setThu(count);
+            case "fri" -> existing.setFri(count);
+            case "sat" -> existing.setSat(count);
+            case "sun" -> existing.setSun(count);
+        }
+
+        postingService.savePosting(memberId, weekStart,
+                existing.getMon(), existing.getTue(), existing.getWed(),
+                existing.getThu(), existing.getFri(), existing.getSat(),
+                existing.getSun(), "batch");
+    }
+
+    private Posting createNewPosting(Long memberId, LocalDate weekStart) {
+        return new Posting(memberId, weekStart, 0, 0, 0, 0, 0, 0, 0, "batch");
+    }
+
+    private LocalDate getWeekStartDate(LocalDate date) {
+        while (date.getDayOfWeek() != DayOfWeek.MONDAY) {
+            date = date.minusDays(1);
+        }
+        return date;
+    }
+}

--- a/src/main/java/com/jk/amazon2/posting/service/RateLimiter.java
+++ b/src/main/java/com/jk/amazon2/posting/service/RateLimiter.java
@@ -1,57 +1,34 @@
 package com.jk.amazon2.posting.service;
 
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 요청 속도 제한을 관리하는 Rate Limiter
- * Semaphore와 AtomicLong을 사용하여 지정된 시간 간격으로 요청 허용
+ * 첫 번째 요청은 즉시 허용, 이후 요청은 지정된 간격만큼 대기
  */
 public class RateLimiter {
 
-    private final long refillIntervalMs; // 요청 간격 (밀리초)
-    private final Semaphore semaphore;
-    private final AtomicLong lastRefillTime;
+    private final long intervalMs;
+    // 다음 요청이 가능한 시각 (초기값 = 현재 → 첫 요청 즉시 허용)
+    private final AtomicLong nextAvailableAt;
 
-    /**
-     * RateLimiter 인스턴스 생성
-     *
-     * @param refillIntervalMs 요청 간격 (밀리초). 예: 2000 = 2초에 1개 요청
-     */
-    public RateLimiter(long refillIntervalMs) {
-        this.refillIntervalMs = refillIntervalMs;
-        this.semaphore = new Semaphore(1);
-        this.lastRefillTime = new AtomicLong(System.currentTimeMillis());
+    public RateLimiter(long intervalMs) {
+        this.intervalMs = intervalMs;
+        this.nextAvailableAt = new AtomicLong(System.currentTimeMillis());
     }
 
-    /**
-     * 요청 토큰 획득
-     * 지정된 시간 간격이 경과하지 않았으면 대기
-     *
-     * @throws RuntimeException 인터럽트된 경우
-     */
-    public void acquire() {
-        refillIfNeeded();
-        try {
-            semaphore.acquire();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Rate limiter interrupted", e);
-        }
-    }
-
-    /**
-     * 필요시 토큰 리필
-     * 마지막 리필 시간으로부터 지정된 간격이 경과했으면 토큰 추가
-     */
-    private void refillIfNeeded() {
+    public synchronized void acquire() {
         long now = System.currentTimeMillis();
-        long lastRefill = lastRefillTime.get();
+        long waitMs = nextAvailableAt.get() - now;
 
-        if (now - lastRefill >= refillIntervalMs) {
-            if (lastRefillTime.compareAndSet(lastRefill, now)) {
-                semaphore.release();
+        if (waitMs > 0) {
+            try {
+                Thread.sleep(waitMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Rate limiter interrupted", e);
             }
         }
+        nextAvailableAt.set(System.currentTimeMillis() + intervalMs);
     }
 }

--- a/src/test/java/com/jk/amazon2/posting/integration/PostingBatchIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/posting/integration/PostingBatchIntegrationTest.java
@@ -1,31 +1,38 @@
 package com.jk.amazon2.posting.integration;
 
+import com.jk.amazon2.member.entity.Member;
+import com.jk.amazon2.member.repository.MemberRepository;
 import com.jk.amazon2.posting.entity.BatchExecution;
-import com.jk.amazon2.posting.entity.Posting;
 import com.jk.amazon2.posting.repository.BatchExecutionRepository;
 import com.jk.amazon2.posting.repository.PostingRepository;
 import com.jk.amazon2.posting.service.BatchService;
-import com.jk.amazon2.member.entity.Member;
-import com.jk.amazon2.member.repository.MemberRepository;
-import com.jk.amazon2.testsupport.IntegrationTestSupport;
-import jakarta.persistence.EntityManager;
+import com.jk.amazon2.posting.service.NaverBlogScraper;
+import com.jk.amazon2.posting.service.RateLimiter;
+import com.jk.amazon2.testsupport.TestContainerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-/**
- * Batch 실행 통합 테스트
- * 배치 실행 시 생성되는 배치 실행 기록과 포스팅 데이터의 정합성을 검증
- */
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Import(TestContainerConfig.class)
 @DisplayName("배치 실행 통합 테스트")
-public class PostingBatchIntegrationTest extends IntegrationTestSupport {
+class PostingBatchIntegrationTest {
 
     @Autowired
     private BatchService batchService;
@@ -40,178 +47,151 @@ public class PostingBatchIntegrationTest extends IntegrationTestSupport {
     private BatchExecutionRepository batchExecutionRepository;
 
     @Autowired
-    private EntityManager entityManager;
-
-    @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private NaverBlogScraper scraper;
+
+    @MockitoBean
+    private RateLimiter rateLimiter;
 
     @BeforeEach
     void setUp() {
-        // 테스트 격리를 위해 테스트 데이터 정리
+        when(scraper.scrapePostingCount(any(), any())).thenReturn(5);
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=0");
+        jdbcTemplate.execute("TRUNCATE TABLE posting_error");
+        jdbcTemplate.execute("TRUNCATE TABLE posting_dead_letter");
         jdbcTemplate.execute("TRUNCATE TABLE posting");
         jdbcTemplate.execute("TRUNCATE TABLE batch_execution");
         jdbcTemplate.execute("TRUNCATE TABLE member");
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=1");
     }
 
-    @DisplayName("[통합] 배치 실행 시 BatchExecution 생성 및 상태 확인")
-    @Test
-    void testBatchExecutionCreated() {
-        // given
-        // 테스트 회원 생성
-        Member member = Member.of("test-user-1", "TECH");
-        memberRepository.save(member);
-        entityManager.flush();
+    @Nested
+    @DisplayName("BatchExecution 상태 검증")
+    class BatchExecutionStatus {
 
-        // 배치 실행
-        LocalDate startDate = LocalDate.of(2026, 6, 9);
-        LocalDate endDate = LocalDate.of(2026, 6, 9);
+        @Test
+        @DisplayName("[통합] 배치 실행 시 BatchExecution 생성 및 COMPLETED 상태 확인 [success]")
+        void batchExecution_created_and_completed() {
+            // given
+            memberRepository.save(Member.of("test-user-1", "TECH"));
+            LocalDate startDate = LocalDate.of(2026, 6, 9);
+            LocalDate endDate = LocalDate.of(2026, 6, 9);
 
-        // when
-        Long batchId = batchService.executeBatch(startDate, endDate, "TEST");
-        entityManager.flush();
+            // when
+            Long batchId = batchService.executeBatch(startDate, endDate, "TEST");
 
-        // then - 배치 실행 기록 확인
-        Optional<BatchExecution> execution = batchExecutionRepository.findById(batchId);
-        assertThat(execution).isPresent();
+            // then
+            Optional<BatchExecution> result = batchExecutionRepository.findById(batchId);
+            assertThat(result).isPresent();
+            BatchExecution execution = result.get();
+            assertSoftly(softly -> {
+                softly.assertThat(execution.getBatchType()).isEqualTo("TEST");
+                softly.assertThat(execution.getStartDate()).isEqualTo(startDate);
+                softly.assertThat(execution.getEndDate()).isEqualTo(endDate);
+                softly.assertThat(execution.getStatus()).isEqualTo("COMPLETED");
+                softly.assertThat(execution.getStartedAt()).isNotNull();
+                softly.assertThat(execution.getCompletedAt()).isNotNull();
+            });
+        }
 
-        BatchExecution batchExecution = execution.get();
-        assertThat(batchExecution.getId()).isEqualTo(batchId);
-        assertThat(batchExecution.getBatchType()).isEqualTo("TEST");
-        assertThat(batchExecution.getStartDate()).isEqualTo(startDate);
-        assertThat(batchExecution.getEndDate()).isEqualTo(endDate);
-        assertThat(batchExecution.getStatus()).isEqualTo("COMPLETED");
-        assertThat(batchExecution.getSuccessCount()).isGreaterThanOrEqualTo(0);
-        assertThat(batchExecution.getCompletedAt()).isNotNull();
+        @Test
+        @DisplayName("[통합] 배치 완료 후 completedAt이 startedAt 이후로 설정 [success]")
+        void batchExecution_completedAt_after_startedAt() {
+            // given
+            memberRepository.save(Member.of("test-user-2", "TECH"));
+
+            // when
+            Long batchId = batchService.executeBatch(
+                    LocalDate.of(2026, 6, 9), LocalDate.of(2026, 6, 9), "TEST");
+
+            // then
+            BatchExecution execution = batchExecutionRepository.findById(batchId).orElseThrow();
+            assertThat(execution.getCompletedAt()).isAfterOrEqualTo(execution.getStartedAt());
+        }
     }
 
-    @DisplayName("[통합] 배치 실행 후 총 카운트 증가 확인")
-    @Test
-    void testBatchExecutionCountIncremented() {
-        // given
-        Member member = Member.of("test-user-2", "TECH");
-        memberRepository.save(member);
-        entityManager.flush();
+    @Nested
+    @DisplayName("BatchExecution 카운트 검증")
+    class BatchExecutionCount {
 
-        LocalDate startDate = LocalDate.of(2026, 6, 9);
-        LocalDate endDate = LocalDate.of(2026, 6, 11);
+        @Test
+        @DisplayName("[통합] 단일 회원 3일 배치 실행 후 totalCount = 3 [success]")
+        void batchExecution_totalCount_single_member() {
+            // given
+            memberRepository.save(Member.of("test-user-3", "TECH"));
 
-        // when
-        Long batchId = batchService.executeBatch(startDate, endDate, "TEST");
-        entityManager.flush();
+            // when
+            Long batchId = batchService.executeBatch(
+                    LocalDate.of(2026, 6, 9), LocalDate.of(2026, 6, 11), "TEST"); // 3일
 
-        // then - 배치 실행 기록에서 totalCount 확인
-        Optional<BatchExecution> execution = batchExecutionRepository.findById(batchId);
-        assertThat(execution).isPresent();
+            // then - 1명 × 3일 = 3
+            BatchExecution execution = batchExecutionRepository.findById(batchId).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(execution.getTotalCount()).isEqualTo(3);
+                softly.assertThat(execution.getSuccessCount()).isEqualTo(3);
+                softly.assertThat(execution.getFailedCount()).isEqualTo(0);
+            });
+        }
 
-        BatchExecution batchExecution = execution.get();
-        // 3일 * 1명 = 최소 3개의 태스크 실행
-        assertThat(batchExecution.getTotalCount()).isGreaterThanOrEqualTo(0);
+        @Test
+        @DisplayName("[통합] 다중 회원 1일 배치 실행 후 totalCount = 2 [success]")
+        void batchExecution_totalCount_multiple_members() {
+            // given
+            memberRepository.save(Member.of("test-user-multi-1", "TECH"));
+            memberRepository.save(Member.of("test-user-multi-2", "TECH"));
+
+            // when
+            Long batchId = batchService.executeBatch(
+                    LocalDate.of(2026, 6, 9), LocalDate.of(2026, 6, 9), "TEST"); // 1일
+
+            // then - 2명 × 1일 = 2
+            BatchExecution execution = batchExecutionRepository.findById(batchId).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(execution.getStatus()).isEqualTo("COMPLETED");
+                softly.assertThat(execution.getTotalCount()).isEqualTo(2);
+                softly.assertThat(execution.getSuccessCount()).isEqualTo(2);
+            });
+        }
     }
 
-    @DisplayName("[통합] 배치 실행 시 배치 실행 기록 DB 저장 확인")
-    @Test
-    void testBatchExecutionSavedToDatabase() {
-        // given
-        Member member = Member.of("test-user-3", "TECH");
-        memberRepository.save(member);
-        entityManager.flush();
+    @Nested
+    @DisplayName("DB 저장 검증")
+    class DatabasePersistence {
 
-        LocalDate startDate = LocalDate.of(2026, 6, 9);
-        LocalDate endDate = LocalDate.of(2026, 6, 10);
+        @Test
+        @DisplayName("[통합] 배치 실행 후 BatchExecution DB 직접 조회 [success]")
+        void batchExecution_saved_to_database() {
+            // given
+            memberRepository.save(Member.of("test-user-4", "TECH"));
 
-        // when
-        Long batchId = batchService.executeBatch(startDate, endDate, "MANUAL");
-        entityManager.flush();
+            // when
+            Long batchId = batchService.executeBatch(
+                    LocalDate.of(2026, 6, 9), LocalDate.of(2026, 6, 10), "MANUAL");
 
-        // then - DB에서 직접 조회하여 저장 확인
-        String sql = "SELECT status FROM batch_execution WHERE id = ?";
-        String status = jdbcTemplate.queryForObject(sql, String.class, batchId);
-        assertThat(status).isEqualTo("COMPLETED");
+            // then
+            String status = jdbcTemplate.queryForObject(
+                    "SELECT status FROM batch_execution WHERE id = ?", String.class, batchId);
+            String batchType = jdbcTemplate.queryForObject(
+                    "SELECT batch_type FROM batch_execution WHERE id = ?", String.class, batchId);
 
-        // 배치 타입 확인
-        String typeSql = "SELECT batch_type FROM batch_execution WHERE id = ?";
-        String batchType = jdbcTemplate.queryForObject(typeSql, String.class, batchId);
-        assertThat(batchType).isEqualTo("MANUAL");
-    }
+            assertThat(status).isEqualTo("COMPLETED");
+            assertThat(batchType).isEqualTo("MANUAL");
+        }
 
-    @DisplayName("[통합] 배치 실행 후 Posting 데이터 생성 확인")
-    @Test
-    void testPostingDataCreatedAfterBatch() {
-        // given
-        Member member = Member.of("test-user-4", "TECH");
-        memberRepository.save(member);
-        Long memberId = member.getId();
-        entityManager.flush();
+        @Test
+        @DisplayName("[통합] 배치 실행 후 Posting 데이터 생성 확인 [success]")
+        void posting_data_created_after_batch() {
+            // given
+            memberRepository.save(Member.of("test-user-5", "TECH"));
 
-        LocalDate targetDate = LocalDate.of(2026, 6, 9); // Monday
-        LocalDate startDate = targetDate;
-        LocalDate endDate = targetDate;
+            // when
+            batchService.executeBatch(
+                    LocalDate.of(2026, 6, 9), LocalDate.of(2026, 6, 9), "TEST");
 
-        // when
-        batchService.executeBatch(startDate, endDate, "TEST");
-        entityManager.flush();
-
-        // then - 포스팅 데이터가 생성되었는지 확인
-        var postings = postingRepository.findAll();
-
-        // 배치 실행이 스크래이핑 실패로 인해 포스팅을 생성하지 않을 수 있으므로
-        // 포스팅 테이블이 비어있거나 데이터가 있을 수 있음
-        assertThat(postings).isNotNull();
-    }
-
-    @DisplayName("[통합] 배치 실행 완료 후 completedAt 설정 확인")
-    @Test
-    void testBatchExecutionCompletedAtSet() {
-        // given
-        Member member = Member.of("test-user-5", "TECH");
-        memberRepository.save(member);
-        entityManager.flush();
-
-        LocalDate startDate = LocalDate.of(2026, 6, 9);
-        LocalDate endDate = LocalDate.of(2026, 6, 9);
-
-        // when
-        Long batchId = batchService.executeBatch(startDate, endDate, "TEST");
-        entityManager.flush();
-
-        // then
-        Optional<BatchExecution> execution = batchExecutionRepository.findById(batchId);
-        assertThat(execution).isPresent();
-
-        BatchExecution batchExecution = execution.get();
-        assertThat(batchExecution.getStatus()).isEqualTo("COMPLETED");
-        assertThat(batchExecution.getCompletedAt()).isNotNull();
-        assertThat(batchExecution.getStartedAt()).isNotNull();
-        assertThat(batchExecution.getCompletedAt()).isAfterOrEqualTo(batchExecution.getStartedAt());
-    }
-
-    @DisplayName("[통합] 다중 회원 배치 실행 확인")
-    @Test
-    void testBatchExecutionWithMultipleMembers() {
-        // given
-        Member member1 = Member.of("test-user-multi-1", "TECH");
-        memberRepository.save(member1);
-
-        Member member2 = Member.of("test-user-multi-2", "TECH");
-        memberRepository.save(member2);
-        entityManager.flush();
-
-        LocalDate startDate = LocalDate.of(2026, 6, 9);
-        LocalDate endDate = LocalDate.of(2026, 6, 9);
-
-        // when
-        Long batchId = batchService.executeBatch(startDate, endDate, "TEST");
-        entityManager.flush();
-
-        // then
-        Optional<BatchExecution> execution = batchExecutionRepository.findById(batchId);
-        assertThat(execution).isPresent();
-
-        BatchExecution batchExecution = execution.get();
-        assertThat(batchExecution.getStatus()).isEqualTo("COMPLETED");
-        // 2명의 회원 * 1일 = 2개의 태스크 (스크래이핑 성공 여부와 무관하게 배치 완료)
-        assertThat(batchExecution.getTotalCount()).isGreaterThanOrEqualTo(0);
+            // then
+            assertThat(postingRepository.findAll()).isNotEmpty();
+        }
     }
 }

--- a/src/test/java/com/jk/amazon2/posting/service/BatchServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/BatchServiceTest.java
@@ -1,6 +1,5 @@
 package com.jk.amazon2.posting.service;
 
-import com.jk.amazon2.posting.entity.BatchExecution;
 import com.jk.amazon2.posting.repository.BatchExecutionRepository;
 import com.jk.amazon2.member.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
@@ -10,7 +9,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.time.LocalDate;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BatchServiceTest {
 
@@ -21,10 +20,13 @@ class BatchServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private PostingService postingService;
+    private NaverBlogScraper scraper;
 
     @Mock
-    private NaverBlogScraper scraper;
+    private RateLimiter rateLimiter;
+
+    @Mock
+    private BatchTaskProcessor batchTaskProcessor;
 
     private BatchService batchService;
 
@@ -34,20 +36,14 @@ class BatchServiceTest {
         batchService = new BatchService(
             batchExecutionRepository,
             memberRepository,
-            postingService,
-            null,
-            null,
             scraper,
-            null,
-            null
+            rateLimiter,
+            batchTaskProcessor
         );
     }
 
     @Test
     void testExecuteBatch() {
-        LocalDate startDate = LocalDate.of(2026, 6, 9);
-        LocalDate endDate = LocalDate.of(2026, 6, 15);
-
-        assertNotNull(batchService);
+        assertThat(batchService).isNotNull();
     }
 }

--- a/src/test/java/com/jk/amazon2/testsupport/RepositoryTestSupport.java
+++ b/src/test/java/com/jk/amazon2/testsupport/RepositoryTestSupport.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 @Import({TestContainerConfig.class, QueryDslTestConfig.class})
 @DataJpaTest
 @AutoConfigureTestDatabase(replace =  AutoConfigureTestDatabase.Replace.NONE)
-public class RepositoryTestSupport {
+public abstract class RepositoryTestSupport {
 }
 
 


### PR DESCRIPTION
## Summary

- `BatchService`에서 멀티스레드 환경의 트랜잭션 경계 위반 문제 해결
- `BatchTaskProcessor`를 별도 Spring 빈으로 분리하여 executor 스레드에서 `@Transactional` 정상 동작
- `RateLimiter` 무한 block 버그 수정
- `PostingBatchIntegrationTest` 완전 재작성으로 통합 테스트 안정화

## Changes

### 핵심 변경
- **`BatchTaskProcessor` 신규**: `processTask()`를 별도 빈으로 분리. `this.processTask()` 내부 호출은 Spring 프록시를 우회하여 `@Transactional`이 동작하지 않는 문제를 해결
- **`BatchService` 리팩토링**: `@Transactional` 제거 후 `future.get()`으로 스레드 완료 보장. 트랜잭션 경계를 `createExecution` / `completeExecution` / `failExecution`으로 명확히 분리
- **`RateLimiter` 버그 수정**: 세마포어 기반 구현에서 두 번째 `acquire()` 호출 시 무한 block되는 버그를 `nextAvailableAt` 방식으로 교체

### 테스트
- **`PostingBatchIntegrationTest` 재작성**: `@MockitoBean`으로 `NaverBlogScraper`/`RateLimiter` 모킹, `@Transactional` 없이 TRUNCATE 기반 데이터 정리
- **`RepositoryTestSupport` abstract 추가**: Gradle이 테스트 클래스로 오인식하는 문제 방지

## Test plan

- [x] `PostingBatchIntegrationTest` 6개 전체 통과
- [x] `RateLimiterTest` 통과 (hang 없음)
- [x] 전체 테스트 166개 통과, 실패 0

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)