### PR TITLE
#4: 포스팅 조회 API 구현

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/controller/PostingController.java
+++ b/src/main/java/com/jk/amazon2/posting/controller/PostingController.java
@@ -4,23 +4,23 @@ import com.jk.amazon2.posting.dto.BatchRequest;
 import com.jk.amazon2.posting.dto.PostingRequest;
 import com.jk.amazon2.posting.dto.PostingResponse;
 import com.jk.amazon2.posting.service.BatchService;
+import com.jk.amazon2.posting.service.PostingService;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 public class PostingController implements PostingApiSpec {
 
+    private final PostingService postingService;
     private final BatchService batchService;
 
     @Override
@@ -29,26 +29,9 @@ public class PostingController implements PostingApiSpec {
             @ParameterObject PostingRequest.PostingSearchDto searchCondition,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-        List<PostingResponse.PostingDto> content = List.of(
-            new PostingResponse.PostingDto(1L, 3, 5, 2, 4, 6, 1, 0),
-            new PostingResponse.PostingDto(2L, 1, 2, 3, 1, 4, 2, 1),
-            new PostingResponse.PostingDto(3L, 0, 1, 2, 3, 5, 3, 2)
+        Page<PostingResponse.PostingDto> page = postingService.getPostings(
+            searchCondition.startDate(), pageable
         );
-
-        Page<PostingResponse.PostingDto> page = new PageImpl<>(
-            content,
-            pageable,
-            content.size()
-        ).map(m -> new PostingResponse.PostingDto(
-                m.memberId(),
-                m.mon(),
-                m.tue(),
-                m.wed(),
-                m.thu(),
-                m.fri(),
-                m.sat(),
-                m.sun()
-        ));
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
+++ b/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
@@ -1,5 +1,7 @@
 package com.jk.amazon2.posting.dto;
 
+import com.jk.amazon2.posting.entity.Posting;
+
 public class PostingResponse {
     public record PostingDto(
             Long memberId,
@@ -10,5 +12,18 @@ public class PostingResponse {
             int fri,
             int sat,
             int sun
-    ) {}
+    ) {
+        public static PostingDto from(Posting posting) {
+            return new PostingDto(
+                posting.getMemberId(),
+                posting.getMon(),
+                posting.getTue(),
+                posting.getWed(),
+                posting.getThu(),
+                posting.getFri(),
+                posting.getSat(),
+                posting.getSun()
+            );
+        }
+    }
 }

--- a/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
+++ b/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
@@ -2,6 +2,8 @@ package com.jk.amazon2.posting.repository;
 
 import com.jk.amazon2.posting.entity.Posting;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +13,12 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public interface PostingRepository extends JpaRepository<Posting, Long> {
+
+    @Query("SELECT p FROM Posting p WHERE p.weekStartDate = :startDate")
+    Page<Posting> findAllByWeekStartDate(
+        @Param("startDate") LocalDate startDate,
+        Pageable pageable
+    );
 
     @Query("SELECT p FROM Posting p WHERE p.memberId = :memberId AND p.weekStartDate = :weekStartDate")
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/jk/amazon2/posting/service/PostingService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/PostingService.java
@@ -1,9 +1,12 @@
 package com.jk.amazon2.posting.service;
 
+import com.jk.amazon2.posting.dto.PostingResponse;
 import com.jk.amazon2.posting.entity.Posting;
 import com.jk.amazon2.posting.repository.PostingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +19,21 @@ import java.time.LocalDate;
 public class PostingService {
 
     private final PostingRepository postingRepository;
+
+    @Transactional(readOnly = true)
+    public Page<PostingResponse.PostingDto> getPostings(LocalDate startDate, Pageable pageable) {
+        return postingRepository.findAllByWeekStartDate(startDate, pageable)
+            .map(p -> new PostingResponse.PostingDto(
+                p.getMemberId(),
+                p.getMon(),
+                p.getTue(),
+                p.getWed(),
+                p.getThu(),
+                p.getFri(),
+                p.getSat(),
+                p.getSun()
+            ));
+    }
 
     @Transactional(isolation = Isolation.SERIALIZABLE)
     public void savePosting(Long memberId, LocalDate weekStartDate,

--- a/src/main/java/com/jk/amazon2/posting/service/PostingService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/PostingService.java
@@ -23,16 +23,7 @@ public class PostingService {
     @Transactional(readOnly = true)
     public Page<PostingResponse.PostingDto> getPostings(LocalDate startDate, Pageable pageable) {
         return postingRepository.findAllByWeekStartDate(startDate, pageable)
-            .map(p -> new PostingResponse.PostingDto(
-                p.getMemberId(),
-                p.getMon(),
-                p.getTue(),
-                p.getWed(),
-                p.getThu(),
-                p.getFri(),
-                p.getSat(),
-                p.getSun()
-            ));
+            .map(PostingResponse.PostingDto::from);
     }
 
     @Transactional(isolation = Isolation.SERIALIZABLE)

--- a/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
@@ -1,58 +1,107 @@
 package com.jk.amazon2.posting.service;
 
+import com.jk.amazon2.posting.dto.PostingResponse;
 import com.jk.amazon2.posting.entity.Posting;
 import com.jk.amazon2.posting.repository.PostingRepository;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class PostingServiceTest {
 
     @Mock
     private PostingRepository postingRepository;
 
+    @InjectMocks
     private PostingService postingService;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        postingService = new PostingService(postingRepository);
-    }
-
     @Test
-    void testSavePosting_NewRecord() {
+    @DisplayName("신규 포스팅 저장")
+    void savePosting_신규_레코드_저장() {
+        // Given
         Long memberId = 1L;
         LocalDate weekStart = LocalDate.of(2026, 6, 9);
-
         when(postingRepository.findByMemberIdAndWeekStartDateWithLock(memberId, weekStart))
             .thenReturn(Optional.empty());
 
+        // When
         postingService.savePosting(memberId, weekStart, 1, 2, 3, 4, 5, 6, 7, "admin");
 
+        // Then
         verify(postingRepository, times(1)).save(any(Posting.class));
     }
 
     @Test
-    void testSavePosting_UpdateExisting() {
+    @DisplayName("기존 포스팅 업데이트")
+    void savePosting_기존_레코드_업데이트() {
+        // Given
         Long memberId = 1L;
         LocalDate weekStart = LocalDate.of(2026, 6, 9);
         Posting existing = new Posting(memberId, weekStart, 1, 1, 1, 1, 1, 1, 1, "admin");
-
         when(postingRepository.findByMemberIdAndWeekStartDateWithLock(memberId, weekStart))
             .thenReturn(Optional.of(existing));
 
+        // When
         postingService.savePosting(memberId, weekStart, 5, 5, 5, 5, 5, 5, 5, "admin");
 
-        assertEquals(5, existing.getMon());
+        // Then
+        assertThat(existing.getMon()).isEqualTo(5);
+        assertThat(existing.getTue()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("날짜 기준 포스팅 목록 조회")
+    void getPostings_날짜_기준_페이징_조회() {
+        // Given
+        LocalDate startDate = LocalDate.of(2026, 6, 9);
+        Pageable pageable = PageRequest.of(0, 10);
+        Posting posting = new Posting(1L, startDate, 1, 2, 3, 4, 5, 6, 7, "admin");
+        Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
+        when(postingRepository.findAllByWeekStartDate(startDate, pageable))
+            .thenReturn(postingPage);
+
+        // When
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, pageable);
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        PostingResponse.PostingDto dto = result.getContent().get(0);
+        assertThat(dto.memberId()).isEqualTo(1L);
+        assertThat(dto.mon()).isEqualTo(1);
+        assertThat(dto.sun()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("해당 날짜 포스팅 없으면 빈 페이지 반환")
+    void getPostings_데이터_없으면_빈_페이지_반환() {
+        // Given
+        LocalDate startDate = LocalDate.of(2026, 6, 9);
+        Pageable pageable = PageRequest.of(0, 10);
+        when(postingRepository.findAllByWeekStartDate(startDate, pageable))
+            .thenReturn(Page.empty(pageable));
+
+        // When
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, pageable);
+
+        // Then
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.getTotalElements()).isZero();
     }
 }


### PR DESCRIPTION
## Summary
- `GET /postings` 엔드포인트의 하드코딩된 더미 데이터 제거
- `PostingRepository`에 날짜 기준 페이징 조회 쿼리 추가
- `PostingService`에 `getPostings()` 조회 메서드 추가
- `PostingController`에서 실제 DB 조회 연결

## Test plan
- [x] `PostingServiceTest` — BDD + AssertJ 형식으로 전환
- [x] 신규 레코드 저장 테스트
- [x] 기존 레코드 업데이트 테스트
- [x] 날짜 기준 페이징 조회 테스트
- [x] 데이터 없을 때 빈 페이지 반환 테스트

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)