### PR TITLE
#26: PostingResponse에 weekStartDate·memberNickname 필드 추가

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
+++ b/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
@@ -2,9 +2,13 @@ package com.jk.amazon2.posting.dto;
 
 import com.jk.amazon2.posting.entity.Posting;
 
+import java.time.LocalDate;
+
 public class PostingResponse {
     public record PostingDto(
             Long memberId,
+            String memberNickname,
+            LocalDate weekStartDate,
             int mon,
             int tue,
             int wed,
@@ -13,9 +17,11 @@ public class PostingResponse {
             int sat,
             int sun
     ) {
-        public static PostingDto from(Posting posting) {
+        public static PostingDto from(Posting posting, String memberNickname) {
             return new PostingDto(
                 posting.getMemberId(),
+                memberNickname,
+                posting.getWeekStartDate(),
                 posting.getMon(),
                 posting.getTue(),
                 posting.getWed(),

--- a/src/main/java/com/jk/amazon2/posting/service/PostingService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/PostingService.java
@@ -1,5 +1,7 @@
 package com.jk.amazon2.posting.service;
 
+import com.jk.amazon2.member.entity.Member;
+import com.jk.amazon2.member.repository.MemberRepository;
 import com.jk.amazon2.posting.dto.PostingResponse;
 import com.jk.amazon2.posting.entity.Posting;
 import com.jk.amazon2.posting.repository.PostingRepository;
@@ -12,6 +14,10 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -19,11 +25,20 @@ import java.time.LocalDate;
 public class PostingService {
 
     private final PostingRepository postingRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
     public Page<PostingResponse.PostingDto> getPostings(LocalDate startDate, Pageable pageable) {
-        return postingRepository.findAllByWeekStartDate(startDate, pageable)
-            .map(PostingResponse.PostingDto::from);
+        Page<Posting> postings = postingRepository.findAllByWeekStartDate(startDate, pageable);
+
+        Set<Long> memberIds = postings.getContent().stream()
+            .map(Posting::getMemberId)
+            .collect(Collectors.toSet());
+
+        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
+            .collect(Collectors.toMap(Member::getId, Member::getNickname));
+
+        return postings.map(p -> PostingResponse.PostingDto.from(p, nicknameMap.get(p.getMemberId())));
     }
 
     @Transactional(isolation = Isolation.SERIALIZABLE)

--- a/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
@@ -1,5 +1,7 @@
 package com.jk.amazon2.posting.service;
 
+import com.jk.amazon2.member.entity.Member;
+import com.jk.amazon2.member.repository.MemberRepository;
 import com.jk.amazon2.posting.dto.PostingResponse;
 import com.jk.amazon2.posting.entity.Posting;
 import com.jk.amazon2.posting.repository.PostingRepository;
@@ -20,13 +22,18 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.*;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class PostingServiceTest {
 
     @Mock
     private PostingRepository postingRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
 
     @InjectMocks
     private PostingService postingService;
@@ -73,8 +80,10 @@ class PostingServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Posting posting = new Posting(1L, startDate, 1, 2, 3, 4, 5, 6, 7, "admin");
         Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
-        when(postingRepository.findAllByWeekStartDate(startDate, pageable))
-            .thenReturn(postingPage);
+        Member member = Member.of("testUser", "CAT01");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        when(postingRepository.findAllByWeekStartDate(startDate, pageable)).thenReturn(postingPage);
+        when(memberRepository.findAllById(anyCollection())).thenReturn(List.of(member));
 
         // When
         Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, pageable);
@@ -84,6 +93,8 @@ class PostingServiceTest {
         assertThat(result.getContent()).hasSize(1);
         PostingResponse.PostingDto dto = result.getContent().get(0);
         assertThat(dto.memberId()).isEqualTo(1L);
+        assertThat(dto.memberNickname()).isEqualTo("testUser");
+        assertThat(dto.weekStartDate()).isEqualTo(startDate);
         assertThat(dto.mon()).isEqualTo(1);
         assertThat(dto.sun()).isEqualTo(7);
     }
@@ -94,8 +105,7 @@ class PostingServiceTest {
         // Given
         LocalDate startDate = LocalDate.of(2026, 6, 9);
         Pageable pageable = PageRequest.of(0, 10);
-        when(postingRepository.findAllByWeekStartDate(startDate, pageable))
-            .thenReturn(Page.empty(pageable));
+        when(postingRepository.findAllByWeekStartDate(startDate, pageable)).thenReturn(Page.empty(pageable));
 
         // When
         Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, pageable);


### PR DESCRIPTION
## Summary

- `PostingResponse.PostingDto`에 `weekStartDate`, `memberNickname` 필드 추가
- `PostingService.getPostings()`에서 `MemberRepository.findAllById()`로 닉네임 배치 조회 후 매핑 (N+1 방지)
- `PostingServiceTest` — Mock 추가 및 새 필드 검증 항목 업데이트

## Test plan

- [x] 단위 테스트 작성 (PostingServiceTest)
- [x] 전체 테스트 통과 (168 tests)
- [x] 리그레션 확인

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)