### PR TITLE
#27: 포스팅 목록 조회 검색 조건 확장 (endDate, memberId)

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/controller/PostingController.java
+++ b/src/main/java/com/jk/amazon2/posting/controller/PostingController.java
@@ -30,7 +30,7 @@ public class PostingController implements PostingApiSpec {
             @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<PostingResponse.PostingDto> page = postingService.getPostings(
-            searchCondition.startDate(), pageable
+            searchCondition.startDate(), searchCondition.endDate(), searchCondition.memberId(), pageable
         );
 
         return ResponseEntity

--- a/src/main/java/com/jk/amazon2/posting/dto/PostingRequest.java
+++ b/src/main/java/com/jk/amazon2/posting/dto/PostingRequest.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 
 public class PostingRequest {
     public record PostingSearchDto(
-            LocalDate startDate
+            LocalDate startDate,
+            LocalDate endDate,
+            Long memberId
     ) {}
 }

--- a/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
+++ b/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
@@ -20,6 +20,19 @@ public interface PostingRepository extends JpaRepository<Posting, Long> {
         Pageable pageable
     );
 
+    @Query("""
+            SELECT p FROM Posting p
+            WHERE (:startDate IS NULL OR p.weekStartDate >= :startDate)
+              AND (:endDate IS NULL OR p.weekStartDate <= :endDate)
+              AND (:memberId IS NULL OR p.memberId = :memberId)
+            """)
+    Page<Posting> findAllBySearchCondition(
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate,
+        @Param("memberId") Long memberId,
+        Pageable pageable
+    );
+
     @Query("SELECT p FROM Posting p WHERE p.memberId = :memberId AND p.weekStartDate = :weekStartDate")
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Posting> findByMemberIdAndWeekStartDateWithLock(

--- a/src/main/java/com/jk/amazon2/posting/service/PostingService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/PostingService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,8 +27,14 @@ public class PostingService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public Page<PostingResponse.PostingDto> getPostings(LocalDate startDate, Pageable pageable) {
-        Page<Posting> postings = postingRepository.findAllByWeekStartDate(startDate, pageable);
+    public Page<PostingResponse.PostingDto> getPostings(
+            LocalDate startDate, LocalDate endDate, Long memberId, Pageable pageable) {
+        // endDate가 null이면 startDate와 같게 설정 → startDate 단독 시 정확 일치 동작 유지
+        LocalDate effectiveEndDate = (endDate != null) ? endDate : startDate;
+
+        Page<Posting> postings = postingRepository.findAllBySearchCondition(
+            startDate, effectiveEndDate, memberId, pageable
+        );
 
         Set<Long> memberIds = postings.getContent().stream()
             .map(Posting::getMemberId)

--- a/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,8 +24,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class PostingServiceTest {
@@ -73,8 +74,8 @@ class PostingServiceTest {
     }
 
     @Test
-    @DisplayName("날짜 기준 포스팅 목록 조회")
-    void getPostings_날짜_기준_페이징_조회() {
+    @DisplayName("startDate만 전달하면 정확 일치 조회 (effectiveEndDate = startDate)")
+    void getPostings_startDate만_전달시_정확일치_조회() {
         // Given
         LocalDate startDate = LocalDate.of(2026, 6, 9);
         Pageable pageable = PageRequest.of(0, 10);
@@ -82,33 +83,84 @@ class PostingServiceTest {
         Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
         Member member = Member.of("testUser", "CAT01");
         ReflectionTestUtils.setField(member, "id", 1L);
-        when(postingRepository.findAllByWeekStartDate(startDate, pageable)).thenReturn(postingPage);
+
+        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(null), eq(pageable)))
+            .thenReturn(postingPage);
         when(memberRepository.findAllById(anyCollection())).thenReturn(List.of(member));
 
         // When
-        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, pageable);
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, null, null, pageable);
 
         // Then
         assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent()).hasSize(1);
         PostingResponse.PostingDto dto = result.getContent().get(0);
-        assertThat(dto.memberId()).isEqualTo(1L);
-        assertThat(dto.memberNickname()).isEqualTo("testUser");
         assertThat(dto.weekStartDate()).isEqualTo(startDate);
-        assertThat(dto.mon()).isEqualTo(1);
-        assertThat(dto.sun()).isEqualTo(7);
+        assertThat(dto.memberNickname()).isEqualTo("testUser");
+        verify(postingRepository).findAllBySearchCondition(startDate, startDate, null, pageable);
     }
 
     @Test
-    @DisplayName("해당 날짜 포스팅 없으면 빈 페이지 반환")
+    @DisplayName("startDate + endDate 전달 시 기간 범위 조회")
+    void getPostings_기간범위_조회() {
+        // Given
+        LocalDate startDate = LocalDate.of(2026, 6, 2);
+        LocalDate endDate = LocalDate.of(2026, 6, 23);
+        Pageable pageable = PageRequest.of(0, 10);
+        Posting posting1 = new Posting(1L, LocalDate.of(2026, 6, 2), 1, 0, 0, 0, 0, 0, 0, "admin");
+        Posting posting2 = new Posting(1L, LocalDate.of(2026, 6, 9), 0, 1, 0, 0, 0, 0, 0, "admin");
+        Page<Posting> postingPage = new PageImpl<>(List.of(posting1, posting2), pageable, 2);
+        Member member = Member.of("testUser", "CAT01");
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(endDate), eq(null), eq(pageable)))
+            .thenReturn(postingPage);
+        when(memberRepository.findAllById(anyCollection())).thenReturn(List.of(member));
+
+        // When
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, endDate, null, pageable);
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        verify(postingRepository).findAllBySearchCondition(startDate, endDate, null, pageable);
+    }
+
+    @Test
+    @DisplayName("memberId 전달 시 특정 멤버만 필터링")
+    void getPostings_memberId_필터링() {
+        // Given
+        LocalDate startDate = LocalDate.of(2026, 6, 9);
+        Long memberId = 2L;
+        Pageable pageable = PageRequest.of(0, 10);
+        Posting posting = new Posting(memberId, startDate, 3, 3, 3, 3, 3, 3, 3, "admin");
+        Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
+        Member member = Member.of("targetUser", "CAT01");
+        ReflectionTestUtils.setField(member, "id", memberId);
+
+        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(memberId), eq(pageable)))
+            .thenReturn(postingPage);
+        when(memberRepository.findAllById(anyCollection())).thenReturn(List.of(member));
+
+        // When
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, null, memberId, pageable);
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).memberId()).isEqualTo(memberId);
+        assertThat(result.getContent().get(0).memberNickname()).isEqualTo("targetUser");
+        verify(postingRepository).findAllBySearchCondition(startDate, startDate, memberId, pageable);
+    }
+
+    @Test
+    @DisplayName("조건 없으면 빈 페이지 반환")
     void getPostings_데이터_없으면_빈_페이지_반환() {
         // Given
         LocalDate startDate = LocalDate.of(2026, 6, 9);
         Pageable pageable = PageRequest.of(0, 10);
-        when(postingRepository.findAllByWeekStartDate(startDate, pageable)).thenReturn(Page.empty(pageable));
+        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(null), eq(pageable)))
+            .thenReturn(Page.empty(pageable));
 
         // When
-        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, pageable);
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, null, null, pageable);
 
         // Then
         assertThat(result.isEmpty()).isTrue();


### PR DESCRIPTION
## Summary

- `PostingSearchDto`에 `endDate`(LocalDate), `memberId`(Long) 필드 추가
- `PostingRepository`에 동적 조건 JPQL 쿼리 `findAllBySearchCondition` 추가
- `PostingService`에서 `endDate` null 시 `effectiveEndDate = startDate`로 치환 → 기존 정확 일치 동작 유지
- `PostingController`에서 새 파라미터 3개 전달하도록 수정

## Test plan

- [ ] `startDate`만 전달 시 기존과 동일하게 정확 일치 동작 확인
- [ ] `startDate` + `endDate` 전달 시 기간 범위 조회 동작 확인
- [ ] `memberId`만 전달 시 특정 멤버 필터링 동작 확인
- [ ] 세 조건 조합 시 AND 필터링 동작 확인
- [ ] 단위 테스트 작성 및 CI 통과 확인

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)