### PR TITLE
#33: Member 이름(name) 필드 추가 - API부터 DB 스키마까지

### DIFF
--- a/src/main/java/com/jk/amazon2/member/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/member/controller/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController implements MemberApiSpec {
     public ResponseEntity<MemberResponse.MemberCreateDto> createMember(
             @RequestBody @Valid MemberRequest.MemberCreateDto request
     ) {
-        MemberCommand.Create command = MemberCommand.Create.of(request.nickname(), request.categoryCode());
+        MemberCommand.Create command = MemberCommand.Create.of(request.nickname(), request.name(), request.categoryCode());
         var createdMember = memberService.create(command);
 
         var response = MemberResponse.MemberCreateDto.from(createdMember);
@@ -63,7 +63,7 @@ public class MemberController implements MemberApiSpec {
             @PathVariable Long id,
             @RequestBody MemberRequest.MemberDto member
     ) {
-        var update = MemberCommand.Update.of(id, member.nickname(), member.categoryCode());
+        var update = MemberCommand.Update.of(id, member.nickname(), member.name(), member.categoryCode());
 
         var response = MemberResponse.MemberUpdateDto.from(memberService.update(update));
         return ResponseEntity

--- a/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
@@ -16,22 +16,24 @@ public class MemberCommand {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Create {
         private String nickname;
+        private String name;
         private String categoryCode;
 
-        public static Create of(String nickname, String categoryCode) {
-            return new Create(nickname, categoryCode);
+        public static Create of(String nickname, String name, String categoryCode) {
+            return new Create(nickname, name, categoryCode);
         }
 
         public static Create from(MemberRequest.MemberDto dto) {
-            return new Create(dto.nickname(), dto.categoryCode());
+            return new Create(dto.nickname(), dto.name(), dto.categoryCode());
         }
 
-        private Create(String nickname, String categoryCode) {
+        private Create(String nickname, String name, String categoryCode) {
             if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Detail - Invalid nickname. nickname={}", nickname);
                 throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
             }
             this.nickname = nickname;
+            this.name = name;
             this.categoryCode = categoryCode;
         }
     }
@@ -42,13 +44,14 @@ public class MemberCommand {
 
         private Long id;
         private String nickname;
+        private String name;
         private String categoryCode;
 
-        public static Update of(Long id, String nickname, String categoryCode) {
-            return new Update(id, nickname, categoryCode);
+        public static Update of(Long id, String nickname, String name, String categoryCode) {
+            return new Update(id, nickname, name, categoryCode);
         }
 
-        private Update(Long id, String nickname, String categoryCode) {
+        private Update(Long id, String nickname, String name, String categoryCode) {
             if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid nickname. nickname={}", nickname);
                 throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
@@ -61,6 +64,7 @@ public class MemberCommand {
 
             this.id = id;
             this.nickname = nickname;
+            this.name = name;
             this.categoryCode = categoryCode;
         }
     }

--- a/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
@@ -29,8 +29,12 @@ public class MemberCommand {
 
         private Create(String nickname, String name, String categoryCode) {
             if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
-                log.warn("[VALIDATION_FAILED] MemberCommand.Detail - Invalid nickname. nickname={}", nickname);
+                log.warn("[VALIDATION_FAILED] MemberCommand.Create - Invalid nickname. nickname={}", nickname);
                 throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
+            }
+            if (name != null && name.length() > 20) {
+                log.warn("[VALIDATION_FAILED] MemberCommand.Create - Invalid name. name={}", name);
+                throw new RestApiException(MemberErrorCode.MEMBER_NAME_INVALID);
             }
             this.nickname = nickname;
             this.name = name;
@@ -56,7 +60,10 @@ public class MemberCommand {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid nickname. nickname={}", nickname);
                 throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
             }
-
+            if (name != null && name.length() > 20) {
+                log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid name. name={}", name);
+                throw new RestApiException(MemberErrorCode.MEMBER_NAME_INVALID);
+            }
             if (categoryCode != null && (categoryCode.isBlank() || categoryCode.length() > 10)) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid categoryCode. categoryCode={}", categoryCode);
                 throw new RestApiException(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID);

--- a/src/main/java/com/jk/amazon2/member/dto/MemberRequest.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 public class MemberRequest {
     public record MemberDto(
             String nickname,
+            String name,
             String categoryCode
     ) {}
 
@@ -19,11 +20,14 @@ public class MemberRequest {
             @NotBlank(message = "닉네임은 필수 입니다.")
             @Size(max = 50, message = "닉네임은 최대 50자까지 입력 가능합니다.")
             String nickname,
+            @NotBlank(message = "이름은 필수 입니다.")
+            @Size(max = 50, message = "이름은 최대 50자까지 입력 가능합니다.")
+            String name,
             @NotBlank(message = "카테고리 코드는 필수 입니다.")
             String categoryCode
     ) {
-        public static MemberCreateDto of(String nickname, String categoryCode) {
-            return new MemberCreateDto(nickname, categoryCode);
+        public static MemberCreateDto of(String nickname, String name, String categoryCode) {
+            return new MemberCreateDto(nickname, name, categoryCode);
         }
     }
 }

--- a/src/main/java/com/jk/amazon2/member/dto/MemberRequest.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberRequest.java
@@ -21,7 +21,7 @@ public class MemberRequest {
             @Size(max = 50, message = "닉네임은 최대 50자까지 입력 가능합니다.")
             String nickname,
             @NotBlank(message = "이름은 필수 입니다.")
-            @Size(max = 50, message = "이름은 최대 50자까지 입력 가능합니다.")
+            @Size(max = 20, message = "이름은 최대 20자까지 입력 가능합니다.")
             String name,
             @NotBlank(message = "카테고리 코드는 필수 입니다.")
             String categoryCode

--- a/src/main/java/com/jk/amazon2/member/dto/MemberResponse.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberResponse.java
@@ -8,6 +8,7 @@ public class MemberResponse {
     public record MemberCreateDto(
             Long id,
             String nickname,
+            String name,
             String categoryCode,
             LocalDate createdAt
     ){
@@ -15,6 +16,7 @@ public class MemberResponse {
             return new MemberCreateDto(
                     detail.getId(),
                     detail.getNickname(),
+                    detail.getName(),
                     detail.getCategoryCode(),
                     detail.getCreatedAt().toLocalDate()
             );
@@ -23,16 +25,18 @@ public class MemberResponse {
 
     public record MemberUpdateDto (
             String nickname,
+            String name,
             String categoryCode
     ){
         public static MemberUpdateDto from(MemberResult.Update update) {
-            return new MemberUpdateDto(update.nickname(), update.categoryCode());
+            return new MemberUpdateDto(update.nickname(), update.name(), update.categoryCode());
         }
     }
 
     public record MemberDetailDto(
             Long id,
             String nickname,
+            String name,
             String categoryCode,
             LocalDate joinDate,
             String status
@@ -41,6 +45,7 @@ public class MemberResponse {
             return new MemberDetailDto(
                     detail.getId(),
                     detail.getNickname(),
+                    detail.getName(),
                     detail.getCategoryCode(),
                     detail.getCreatedAt().toLocalDate(),
                     detail.isDeleted() ? "deleted" : "active"
@@ -50,6 +55,7 @@ public class MemberResponse {
 
     public record MemberListDto(
             String nickname,
+            String name,
             String categoryName,
             LocalDate joinDate,
             String status
@@ -57,6 +63,7 @@ public class MemberResponse {
         public static MemberListDto from(MemberResult.Summary summary) {
             return new MemberListDto(
                     summary.nickname(),
+                    summary.name(),
                     summary.categoryName(),
                     summary.createdAt().toLocalDate(),
                     summary.deleted() ? "deleted" : "active"

--- a/src/main/java/com/jk/amazon2/member/dto/MemberResult.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberResult.java
@@ -17,6 +17,7 @@ public class MemberResult {
     public static class Detail {
         private Long id;
         private String nickname;
+        private String name;
         private String categoryCode;
         private LocalDateTime createdAt;
         private boolean deleted;
@@ -25,6 +26,7 @@ public class MemberResult {
             return new Detail(
                     member.getId(),
                     member.getNickname(),
+                    member.getName(),
                     member.getCategoryCode(),
                     member.getCreatedAt(),
                     member.isDeleted()
@@ -34,15 +36,17 @@ public class MemberResult {
 
     public record Update(
             String nickname,
+            String name,
             String categoryCode
     ) {
-        public static Update of(String nickname, String categoryCode) {
-            return new Update(nickname, categoryCode);
+        public static Update of(String nickname, String name, String categoryCode) {
+            return new Update(nickname, name, categoryCode);
         }
     }
 
     public record Summary(
             String nickname,
+            String name,
             String categoryName,
             LocalDateTime createdAt,
             boolean deleted

--- a/src/main/java/com/jk/amazon2/member/entity/Member.java
+++ b/src/main/java/com/jk/amazon2/member/entity/Member.java
@@ -21,20 +21,25 @@ public class Member extends BaseAudit {
     @Column(name = "nickname", nullable = false, unique = true, length = 50)
     private String nickname;
 
+    @Column(name = "name", length = 50)
+    private String name;
+
     @Column(name = "deleted", nullable = false, columnDefinition = "TINYINT(1) NOT NULL DEFAULT 0")
     private boolean deleted = Boolean.FALSE;
 
-    public static Member of(String nickname, String categoryCode) {
+    public static Member of(String nickname, String name, String categoryCode) {
         Member member = new Member();
         member.nickname = nickname;
+        member.name = name;
         member.categoryCode = categoryCode;
         return member;
     }
 
-    public void update(String nickname, String categoryCode) {
+    public void update(String nickname, String name, String categoryCode) {
         if (nickname != null) {
             this.nickname = nickname;
         }
+        this.name = name;
         this.categoryCode = categoryCode;
     }
 

--- a/src/main/java/com/jk/amazon2/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/jk/amazon2/member/exception/MemberErrorCode.java
@@ -13,7 +13,8 @@ public enum MemberErrorCode implements ErrorCode{
     MEMBER_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 필수 입니다."),
     MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다."),
     MEMBER_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 닉네임 입니다."),
-    MEMBER_CATEGORY_CODE_INVALID(HttpStatus.BAD_REQUEST, "카테고리 코드는 최대 10자까지 입력 가능합니다.");
+    MEMBER_CATEGORY_CODE_INVALID(HttpStatus.BAD_REQUEST, "카테고리 코드는 최대 10자까지 입력 가능합니다."),
+    MEMBER_NAME_INVALID(HttpStatus.BAD_REQUEST, "이름은 최대 20자까지 입력 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/jk/amazon2/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/jk/amazon2/member/repository/MemberRepositoryImpl.java
@@ -26,6 +26,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(Projections.constructor(
                         MemberResult.Summary.class,
                         member.nickname,
+                        member.name,
                         category.name,
                         member.createdAt,
                         member.deleted

--- a/src/main/java/com/jk/amazon2/member/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/member/service/MemberService.java
@@ -30,6 +30,7 @@ public class MemberService {
 
         Member member = Member.of(
                 command.getNickname(),
+                command.getName(),
                 command.getCategoryCode()
         );
 
@@ -45,8 +46,8 @@ public class MemberService {
 
         categoryValidationPort.validateCategoryExists(command.getCategoryCode());
 
-        member.update(command.getNickname(), command.getCategoryCode());
-        return MemberResult.Update.of(member.getNickname(), member.getCategoryCode());
+        member.update(command.getNickname(), command.getName(), command.getCategoryCode());
+        return MemberResult.Update.of(member.getNickname(), member.getName(), member.getCategoryCode());
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V1.3__Add_Member_Name_Column.sql
+++ b/src/main/resources/db/migration/V1.3__Add_Member_Name_Column.sql
@@ -1,0 +1,4 @@
+-- V1.3__Add_Member_Name_Column.sql
+
+ALTER TABLE member
+    ADD COLUMN name VARCHAR(50) NULL AFTER nickname;

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
@@ -60,8 +60,8 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
             String nickname = "updated_member";
             String categoryCode = "DESIGN";
 
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null, categoryCode);
-            MemberResult.Update updateResult = MemberResult.Update.of(nickname, null, categoryCode);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", categoryCode);
+            MemberResult.Update updateResult = MemberResult.Update.of(nickname, "test-name", categoryCode);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willReturn(updateResult);
@@ -84,8 +84,8 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
             Long memberId = 1L;
             String nickname = "updated_member";
 
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null, null);
-            MemberResult.Update updateResult = MemberResult.Update.of(nickname, null, null);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", null);
+            MemberResult.Update updateResult = MemberResult.Update.of(nickname, "test-name", null);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willReturn(updateResult);
@@ -106,7 +106,7 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         void updateMember_fail(String scenario, String nickname, String categoryCode, MemberErrorCode errorCode) throws Exception {
             // given
             Long memberId = 1L;
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null, categoryCode);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", categoryCode);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willThrow(new RestApiException(errorCode));
@@ -185,11 +185,11 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
                 int expectedCount
         ) {
             List<MemberResult.Summary> allData = List.of(
-                    new MemberResult.Summary("dev_user1", null, "DEV", LocalDateTime.now(), false),
-                    new MemberResult.Summary("dev_user2", null, "DEV", LocalDateTime.now(), false),
-                    new MemberResult.Summary("design_user", null, "DESIGN", LocalDateTime.now(), false),
-                    new MemberResult.Summary("deleted_dev_user", null, "DEV", LocalDateTime.now(), true),
-                    new MemberResult.Summary("deleted_design_user", null, "DESIGN", LocalDateTime.now(), true)
+                    new MemberResult.Summary("dev_user1", "test-name", "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("dev_user2", "name-2", "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("design_user", "name-3", "DESIGN", LocalDateTime.now(), false),
+                    new MemberResult.Summary("deleted_dev_user", "name-4", "DEV", LocalDateTime.now(), true),
+                    new MemberResult.Summary("deleted_design_user", "name-5", "DESIGN", LocalDateTime.now(), true)
             );
 
             return allData.stream()
@@ -214,7 +214,7 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
             int start = pageNumber * pageSize;
             int end = Math.min(start + pageSize, totalElements);
             for (int i = start; i < end; i++) {
-                content.add(new MemberResult.Summary("user" + i, null, "DEV", LocalDateTime.now(), false));
+                content.add(new MemberResult.Summary("user" + i, "name-" + i, "DEV", LocalDateTime.now(), false));
             }
 
             Pageable pageable = PageRequest.of(pageNumber, pageSize);
@@ -269,8 +269,8 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         void getMembers_success_status_conversion() throws Exception {
             // given
             List<MemberResult.Summary> content = List.of(
-                    new MemberResult.Summary("dev_user1", null, "DEV", LocalDateTime.now(), false),
-                    new MemberResult.Summary("deleted_dev_user", null, "DEV", LocalDateTime.now(), true)
+                    new MemberResult.Summary("dev_user1", "test-name", "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("deleted_dev_user", "name-2", "DEV", LocalDateTime.now(), true)
             );
             Page<MemberResult.Summary> pageResult = new PageImpl<>(content, PageRequest.of(0, 10), 2);
 

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
@@ -60,8 +60,8 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
             String nickname = "updated_member";
             String categoryCode = "DESIGN";
 
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, categoryCode);
-            MemberResult.Update updateResult = MemberResult.Update.of(nickname, categoryCode);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null, categoryCode);
+            MemberResult.Update updateResult = MemberResult.Update.of(nickname, null, categoryCode);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willReturn(updateResult);
@@ -84,8 +84,8 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
             Long memberId = 1L;
             String nickname = "updated_member";
 
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null);
-            MemberResult.Update updateResult = MemberResult.Update.of(nickname, null);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null, null);
+            MemberResult.Update updateResult = MemberResult.Update.of(nickname, null, null);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willReturn(updateResult);
@@ -106,7 +106,7 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         void updateMember_fail(String scenario, String nickname, String categoryCode, MemberErrorCode errorCode) throws Exception {
             // given
             Long memberId = 1L;
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, categoryCode);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, null, categoryCode);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willThrow(new RestApiException(errorCode));
@@ -185,11 +185,11 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
                 int expectedCount
         ) {
             List<MemberResult.Summary> allData = List.of(
-                    new MemberResult.Summary("dev_user1", "DEV", LocalDateTime.now(), false),
-                    new MemberResult.Summary("dev_user2", "DEV", LocalDateTime.now(), false),
-                    new MemberResult.Summary("design_user", "DESIGN", LocalDateTime.now(), false),
-                    new MemberResult.Summary("deleted_dev_user", "DEV", LocalDateTime.now(), true),
-                    new MemberResult.Summary("deleted_design_user", "DESIGN", LocalDateTime.now(), true)
+                    new MemberResult.Summary("dev_user1", null, "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("dev_user2", null, "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("design_user", null, "DESIGN", LocalDateTime.now(), false),
+                    new MemberResult.Summary("deleted_dev_user", null, "DEV", LocalDateTime.now(), true),
+                    new MemberResult.Summary("deleted_design_user", null, "DESIGN", LocalDateTime.now(), true)
             );
 
             return allData.stream()
@@ -214,7 +214,7 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
             int start = pageNumber * pageSize;
             int end = Math.min(start + pageSize, totalElements);
             for (int i = start; i < end; i++) {
-                content.add(new MemberResult.Summary("user" + i, "DEV", LocalDateTime.now(), false));
+                content.add(new MemberResult.Summary("user" + i, null, "DEV", LocalDateTime.now(), false));
             }
 
             Pageable pageable = PageRequest.of(pageNumber, pageSize);
@@ -269,8 +269,8 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         void getMembers_success_status_conversion() throws Exception {
             // given
             List<MemberResult.Summary> content = List.of(
-                    new MemberResult.Summary("dev_user1", "DEV", LocalDateTime.now(), false),
-                    new MemberResult.Summary("deleted_dev_user", "DEV", LocalDateTime.now(), true)
+                    new MemberResult.Summary("dev_user1", null, "DEV", LocalDateTime.now(), false),
+                    new MemberResult.Summary("deleted_dev_user", null, "DEV", LocalDateTime.now(), true)
             );
             Page<MemberResult.Summary> pageResult = new PageImpl<>(content, PageRequest.of(0, 10), 2);
 

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
@@ -56,9 +56,9 @@ class MemberControllerTest {
             String nickname = "test_member";
             String categoryCode = "DEV";
 
-            var request = new MemberRequest.MemberCreateDto(nickname, null, categoryCode);
+            var request = new MemberRequest.MemberCreateDto(nickname, "test-name", categoryCode);
 
-            var savedMember = MemberResult.Detail.of(id, nickname, null, categoryCode, LocalDateTime.now(), false);
+            var savedMember = MemberResult.Detail.of(id, nickname, "test-name", categoryCode, LocalDateTime.now(), false);
             given(memberService.create(any(MemberCommand.Create.class)))
                     .willReturn(savedMember);
 
@@ -71,7 +71,7 @@ class MemberControllerTest {
         @MethodSource("provideCreateMemberFailureCases")
         void createMember_fail(String scenario, String nickname, String categoryCode, ErrorCode errorCode) {
             // given
-            var request = new MemberRequest.MemberCreateDto(nickname, null, categoryCode);
+            var request = new MemberRequest.MemberCreateDto(nickname, "test-name", categoryCode);
 
             // 서비스 로직 에러인 경우에만 Mocking (유효성 검사 실패는 서비스 호출 전 발생)
             if (errorCode == MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS || errorCode == CategoryErrorCode.CATEGORY_NOT_FOUND) {
@@ -136,7 +136,7 @@ class MemberControllerTest {
         void getMember_success() {
             // given
             Long id = 1L;
-            var result = MemberResult.Detail.of(id, "test_member", null, "DEV", LocalDateTime.now(), false);
+            var result = MemberResult.Detail.of(id, "test_member", "test-name", "DEV", LocalDateTime.now(), false);
             given(memberService.findById(id))
                     .willReturn(result);
 

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
@@ -56,9 +56,9 @@ class MemberControllerTest {
             String nickname = "test_member";
             String categoryCode = "DEV";
 
-            var request = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+            var request = new MemberRequest.MemberCreateDto(nickname, null, categoryCode);
 
-            var savedMember = MemberResult.Detail.of(id, nickname, categoryCode, LocalDateTime.now(), false);
+            var savedMember = MemberResult.Detail.of(id, nickname, null, categoryCode, LocalDateTime.now(), false);
             given(memberService.create(any(MemberCommand.Create.class)))
                     .willReturn(savedMember);
 
@@ -71,7 +71,7 @@ class MemberControllerTest {
         @MethodSource("provideCreateMemberFailureCases")
         void createMember_fail(String scenario, String nickname, String categoryCode, ErrorCode errorCode) {
             // given
-            var request = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+            var request = new MemberRequest.MemberCreateDto(nickname, null, categoryCode);
 
             // 서비스 로직 에러인 경우에만 Mocking (유효성 검사 실패는 서비스 호출 전 발생)
             if (errorCode == MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS || errorCode == CategoryErrorCode.CATEGORY_NOT_FOUND) {
@@ -136,7 +136,7 @@ class MemberControllerTest {
         void getMember_success() {
             // given
             Long id = 1L;
-            var result = MemberResult.Detail.of(id, "test_member", "DEV", LocalDateTime.now(), false);
+            var result = MemberResult.Detail.of(id, "test_member", null, "DEV", LocalDateTime.now(), false);
             given(memberService.findById(id))
                     .willReturn(result);
 

--- a/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
@@ -64,7 +64,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             // 닉네임 길이 제한(50자)에 맞게 자르기
             if (nickname.length() > 50) nickname = nickname.substring(0, 50);
 
-            var requestDto = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+            var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
 
             // when & then (API 검증)
             RestAssuredMockMvc
@@ -104,7 +104,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                 // 이미 존재하면 무시
             }
 
-            var requestDto = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+            var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
 
             // when & then
             RestAssuredMockMvc
@@ -134,7 +134,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
 
             String nickname = "new_user";
             // 존재하지 않는 카테고리 코드 (10자 이하)
-            var requestDto = new MemberRequest.MemberCreateDto(nickname, categoryCode);
+            var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
 
             // when & then
             RestAssuredMockMvc
@@ -277,7 +277,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
 
             String updatedNickname = "updated_user";
             String updatedCategoryCode = "DESIGN";
-            var requestDto = new MemberRequest.MemberDto(updatedNickname, updatedCategoryCode);
+            var requestDto = new MemberRequest.MemberDto(updatedNickname, null, updatedCategoryCode);
 
             // when & then
             RestAssuredMockMvc

--- a/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
@@ -54,9 +54,10 @@ class MemberServiceTest {
             // given
             Long id = 1L;
             String nickname = "test";
+            String name = "테스터";
             String categoryCode = "TEST";
 
-            var inputMember = MemberCommand.Create.of(nickname, categoryCode);
+            var inputMember = MemberCommand.Create.of(nickname, name, categoryCode);
 
             given(memberRepository.existsByNickname(any(String.class)))
                     .willReturn(false);
@@ -75,6 +76,7 @@ class MemberServiceTest {
             assertThat(savedMember).isNotNull();
             SoftAssertions.assertSoftly(softly ->{
                 softly.assertThat(savedMember.getNickname()).isEqualTo(nickname);
+                softly.assertThat(savedMember.getName()).isEqualTo(name);
                 softly.assertThat(savedMember.getCategoryCode()).isEqualTo(categoryCode);
                 softly.assertThat(savedMember.getId()).isEqualTo(id);
             });
@@ -86,6 +88,7 @@ class MemberServiceTest {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(capturedCommand.getId()).as("유저의 id 검증").isEqualTo(id);
                 softly.assertThat(capturedCommand.getNickname()).as("유저명 검증").isEqualTo(nickname);
+                softly.assertThat(capturedCommand.getName()).as("이름 검증").isEqualTo(name);
                 softly.assertThat(capturedCommand.getCategoryCode()).as("카테고리 코드 검증").isEqualTo(categoryCode);
             });
         }
@@ -96,7 +99,7 @@ class MemberServiceTest {
             // given
             String nickname = "test";
             String categoryCode = "NON_EXISTENT_CODE";
-            var inputMember = MemberCommand.Create.of(nickname, categoryCode);
+            var inputMember = MemberCommand.Create.of(nickname, null, categoryCode);
 
             doThrow(new RestApiException(CategoryErrorCode.CATEGORY_NOT_FOUND))
                     .when(categoryValidationPort).validateCategoryExists(categoryCode);
@@ -114,7 +117,7 @@ class MemberServiceTest {
             String nickname = "duplicate_user";
             String categoryCode = "TEST";
 
-            var inputMember = MemberCommand.Create.of(nickname, categoryCode);
+            var inputMember = MemberCommand.Create.of(nickname, null, categoryCode);
 
             given(memberRepository.existsByNickname(any(String.class)))
                     .willReturn(true);
@@ -135,11 +138,12 @@ class MemberServiceTest {
             // given
             Long id = 1L;
             String newNickname = "updated_member";
+            String newName = "수정된이름";
             String newCategoryCode = "UPDATED";
-            Member member = Member.of("test_member", "DEV");
+            Member member = Member.of("test_member", null, "DEV");
             ReflectionTestUtils.setField(member, "id", id);
 
-            var updateCommand = MemberCommand.Update.of(id, newNickname, newCategoryCode);
+            var updateCommand = MemberCommand.Update.of(id, newNickname, newName, newCategoryCode);
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));
 
@@ -149,6 +153,7 @@ class MemberServiceTest {
             // then
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(result.nickname()).isEqualTo(newNickname);
+                softly.assertThat(result.name()).isEqualTo(newName);
                 softly.assertThat(result.categoryCode()).isEqualTo(newCategoryCode);
             });
             verify(categoryValidationPort).validateCategoryExists(newCategoryCode);
@@ -161,7 +166,7 @@ class MemberServiceTest {
             Long id = 999L;
             String newNickname = "updated_member";
             String newCategoryCode = "UPDATED";
-            var updateCommand = MemberCommand.Update.of(id, newNickname, newCategoryCode);
+            var updateCommand = MemberCommand.Update.of(id, newNickname, null, newCategoryCode);
 
             given(memberRepository.findById(id))
                     .willReturn(Optional.empty());
@@ -179,9 +184,9 @@ class MemberServiceTest {
             Long id = 1L;
             String newNickname = "updated_member";
             String newCategoryCode = "NOTEXIST";
-            Member member = Member.of("test_member", "DEV");
+            Member member = Member.of("test_member", null, "DEV");
             ReflectionTestUtils.setField(member, "id", id);
-            var updateCommand = MemberCommand.Update.of(id, newNickname, newCategoryCode);
+            var updateCommand = MemberCommand.Update.of(id, newNickname, null, newCategoryCode);
 
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));
@@ -203,7 +208,7 @@ class MemberServiceTest {
         void delete_success() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", "DEV");
+            Member member = Member.of("test_member", null, "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));
@@ -220,7 +225,7 @@ class MemberServiceTest {
         void delete_success_already_deleted() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", "DEV");
+            Member member = Member.of("test_member", null, "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             member.softDelete();
             given(memberRepository.findById(id))
@@ -256,7 +261,7 @@ class MemberServiceTest {
         void findById_success() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", "DEV");
+            Member member = Member.of("test_member", null, "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));
@@ -297,7 +302,7 @@ class MemberServiceTest {
         void hardDelete_success() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", "DEV");
+            Member member = Member.of("test_member", null, "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             member.softDelete();
             given(memberRepository.findById(id))
@@ -329,7 +334,7 @@ class MemberServiceTest {
         void hardDelete_fail_not_deleted() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", "DEV");
+            Member member = Member.of("test_member", null, "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));

--- a/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
@@ -54,7 +54,7 @@ class MemberServiceTest {
             // given
             Long id = 1L;
             String nickname = "test";
-            String name = "테스터";
+            String name = "test-name";
             String categoryCode = "TEST";
 
             var inputMember = MemberCommand.Create.of(nickname, name, categoryCode);
@@ -99,7 +99,7 @@ class MemberServiceTest {
             // given
             String nickname = "test";
             String categoryCode = "NON_EXISTENT_CODE";
-            var inputMember = MemberCommand.Create.of(nickname, null, categoryCode);
+            var inputMember = MemberCommand.Create.of(nickname, "test-name", categoryCode);
 
             doThrow(new RestApiException(CategoryErrorCode.CATEGORY_NOT_FOUND))
                     .when(categoryValidationPort).validateCategoryExists(categoryCode);
@@ -117,7 +117,7 @@ class MemberServiceTest {
             String nickname = "duplicate_user";
             String categoryCode = "TEST";
 
-            var inputMember = MemberCommand.Create.of(nickname, null, categoryCode);
+            var inputMember = MemberCommand.Create.of(nickname, "test-name", categoryCode);
 
             given(memberRepository.existsByNickname(any(String.class)))
                     .willReturn(true);
@@ -138,9 +138,9 @@ class MemberServiceTest {
             // given
             Long id = 1L;
             String newNickname = "updated_member";
-            String newName = "수정된이름";
+            String newName = "updated-name";
             String newCategoryCode = "UPDATED";
-            Member member = Member.of("test_member", null, "DEV");
+            Member member = Member.of("test_member", "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
 
             var updateCommand = MemberCommand.Update.of(id, newNickname, newName, newCategoryCode);
@@ -166,7 +166,7 @@ class MemberServiceTest {
             Long id = 999L;
             String newNickname = "updated_member";
             String newCategoryCode = "UPDATED";
-            var updateCommand = MemberCommand.Update.of(id, newNickname, null, newCategoryCode);
+            var updateCommand = MemberCommand.Update.of(id, newNickname, "updated-name", newCategoryCode);
 
             given(memberRepository.findById(id))
                     .willReturn(Optional.empty());
@@ -184,9 +184,9 @@ class MemberServiceTest {
             Long id = 1L;
             String newNickname = "updated_member";
             String newCategoryCode = "NOTEXIST";
-            Member member = Member.of("test_member", null, "DEV");
+            Member member = Member.of("test_member", "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
-            var updateCommand = MemberCommand.Update.of(id, newNickname, null, newCategoryCode);
+            var updateCommand = MemberCommand.Update.of(id, newNickname, "updated-name", newCategoryCode);
 
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));
@@ -208,7 +208,7 @@ class MemberServiceTest {
         void delete_success() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", null, "DEV");
+            Member member = Member.of("test_member", "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));
@@ -225,7 +225,7 @@ class MemberServiceTest {
         void delete_success_already_deleted() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", null, "DEV");
+            Member member = Member.of("test_member", "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             member.softDelete();
             given(memberRepository.findById(id))
@@ -261,7 +261,7 @@ class MemberServiceTest {
         void findById_success() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", null, "DEV");
+            Member member = Member.of("test_member", "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));
@@ -302,7 +302,7 @@ class MemberServiceTest {
         void hardDelete_success() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", null, "DEV");
+            Member member = Member.of("test_member", "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             member.softDelete();
             given(memberRepository.findById(id))
@@ -334,7 +334,7 @@ class MemberServiceTest {
         void hardDelete_fail_not_deleted() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", null, "DEV");
+            Member member = Member.of("test_member", "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
             given(memberRepository.findById(id))
                     .willReturn(Optional.of(member));

--- a/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
@@ -34,7 +34,7 @@ class MemberCommandTest {
             String categoryCode = "DEV";
 
             // when
-            MemberCommand.Create command = MemberCommand.Create.of(nickname, categoryCode);
+            MemberCommand.Create command = MemberCommand.Create.of(nickname, null, categoryCode);
 
             // then
             assertSoftly(softly -> {
@@ -51,7 +51,7 @@ class MemberCommandTest {
                 String invalidNickname
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Create.of(invalidNickname, "DEV"))
+            assertThatThrownBy(() -> MemberCommand.Create.of(invalidNickname, null, "DEV"))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
         }
@@ -78,7 +78,7 @@ class MemberCommandTest {
                 String categoryCode
         ) {
             // when
-            MemberCommand.Update command = MemberCommand.Update.of(1L, nickname, categoryCode);
+            MemberCommand.Update command = MemberCommand.Update.of(1L, nickname, null, categoryCode);
 
             // then
             assertThat(command).isNotNull();
@@ -105,7 +105,7 @@ class MemberCommandTest {
                 String categoryCode
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of(1L, invalidNickname, categoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of(1L, invalidNickname, null, categoryCode))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
         }
@@ -128,7 +128,7 @@ class MemberCommandTest {
                 String invalidCategoryCode
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of(1L, nickname, invalidCategoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of(1L, nickname, null, invalidCategoryCode))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID.getMessage());
         }

--- a/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
@@ -64,6 +64,35 @@ class MemberCommandTest {
                     of("nickname이 50자를 초과하는 경우", "a".repeat(51))
             );
         }
+
+        @Test
+        @DisplayName("name이 20자를 초과하면 생성 실패 [fail]")
+        void create_fail_invalid_name() {
+            // when & then
+            assertThatThrownBy(() -> MemberCommand.Create.of("tester", "a".repeat(21), "DEV"))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID.getMessage());
+        }
+
+        @Test
+        @DisplayName("name이 null이면 생성 성공 (선택값) [success]")
+        void create_success_name_null() {
+            // when
+            MemberCommand.Create command = MemberCommand.Create.of("tester", null, "DEV");
+
+            // then
+            assertThat(command.getName()).isNull();
+        }
+
+        @Test
+        @DisplayName("name이 20자이면 생성 성공 [success]")
+        void create_success_name_max_length() {
+            // when
+            MemberCommand.Create command = MemberCommand.Create.of("tester", "a".repeat(20), "DEV");
+
+            // then
+            assertThat(command.getName()).isEqualTo("a".repeat(20));
+        }
     }
 
     @Nested
@@ -139,6 +168,25 @@ class MemberCommandTest {
                     of("categoryCode가 공백인 경우", "tester", "   "),
                     of("categoryCode가 10자를 초과하는 경우", "tester", "a".repeat(11))
             );
+        }
+
+        @Test
+        @DisplayName("name이 20자를 초과하면 수정 실패 [fail]")
+        void update_fail_invalid_name() {
+            // when & then
+            assertThatThrownBy(() -> MemberCommand.Update.of(1L, "tester", "a".repeat(21), "DEV"))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID.getMessage());
+        }
+
+        @Test
+        @DisplayName("name이 null이면 수정 성공 (선택값) [success]")
+        void update_success_name_null() {
+            // when
+            MemberCommand.Update command = MemberCommand.Update.of(1L, "tester", null, "DEV");
+
+            // then
+            assertThat(command.getName()).isNull();
         }
     }
 

--- a/src/test/java/com/jk/amazon2/posting/integration/PostingBatchIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/posting/integration/PostingBatchIntegrationTest.java
@@ -76,7 +76,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 실행 시 BatchExecution 생성 및 COMPLETED 상태 확인 [success]")
         void batchExecution_created_and_completed() {
             // given
-            memberRepository.save(Member.of("test-user-1", "TECH"));
+            memberRepository.save(Member.of("test-user-1", null, "TECH"));
             LocalDate startDate = LocalDate.of(2026, 6, 9);
             LocalDate endDate = LocalDate.of(2026, 6, 9);
 
@@ -101,7 +101,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 완료 후 completedAt이 startedAt 이후로 설정 [success]")
         void batchExecution_completedAt_after_startedAt() {
             // given
-            memberRepository.save(Member.of("test-user-2", "TECH"));
+            memberRepository.save(Member.of("test-user-2", null, "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -121,7 +121,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 단일 회원 3일 배치 실행 후 totalCount = 3 [success]")
         void batchExecution_totalCount_single_member() {
             // given
-            memberRepository.save(Member.of("test-user-3", "TECH"));
+            memberRepository.save(Member.of("test-user-3", null, "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -140,8 +140,8 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 다중 회원 1일 배치 실행 후 totalCount = 2 [success]")
         void batchExecution_totalCount_multiple_members() {
             // given
-            memberRepository.save(Member.of("test-user-multi-1", "TECH"));
-            memberRepository.save(Member.of("test-user-multi-2", "TECH"));
+            memberRepository.save(Member.of("test-user-multi-1", null, "TECH"));
+            memberRepository.save(Member.of("test-user-multi-2", null, "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -165,7 +165,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 실행 후 BatchExecution DB 직접 조회 [success]")
         void batchExecution_saved_to_database() {
             // given
-            memberRepository.save(Member.of("test-user-4", "TECH"));
+            memberRepository.save(Member.of("test-user-4", null, "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -185,7 +185,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 실행 후 Posting 데이터 생성 확인 [success]")
         void posting_data_created_after_batch() {
             // given
-            memberRepository.save(Member.of("test-user-5", "TECH"));
+            memberRepository.save(Member.of("test-user-5", null, "TECH"));
 
             // when
             batchService.executeBatch(

--- a/src/test/java/com/jk/amazon2/posting/integration/PostingBatchIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/posting/integration/PostingBatchIntegrationTest.java
@@ -76,7 +76,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 실행 시 BatchExecution 생성 및 COMPLETED 상태 확인 [success]")
         void batchExecution_created_and_completed() {
             // given
-            memberRepository.save(Member.of("test-user-1", null, "TECH"));
+            memberRepository.save(Member.of("test-user-1", "test-name-1", "TECH"));
             LocalDate startDate = LocalDate.of(2026, 6, 9);
             LocalDate endDate = LocalDate.of(2026, 6, 9);
 
@@ -101,7 +101,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 완료 후 completedAt이 startedAt 이후로 설정 [success]")
         void batchExecution_completedAt_after_startedAt() {
             // given
-            memberRepository.save(Member.of("test-user-2", null, "TECH"));
+            memberRepository.save(Member.of("test-user-2", "test-name-2", "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -121,7 +121,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 단일 회원 3일 배치 실행 후 totalCount = 3 [success]")
         void batchExecution_totalCount_single_member() {
             // given
-            memberRepository.save(Member.of("test-user-3", null, "TECH"));
+            memberRepository.save(Member.of("test-user-3", "test-name-3", "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -140,8 +140,8 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 다중 회원 1일 배치 실행 후 totalCount = 2 [success]")
         void batchExecution_totalCount_multiple_members() {
             // given
-            memberRepository.save(Member.of("test-user-multi-1", null, "TECH"));
-            memberRepository.save(Member.of("test-user-multi-2", null, "TECH"));
+            memberRepository.save(Member.of("test-user-multi-1", "test-name-4", "TECH"));
+            memberRepository.save(Member.of("test-user-multi-2", "test-name-5", "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -165,7 +165,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 실행 후 BatchExecution DB 직접 조회 [success]")
         void batchExecution_saved_to_database() {
             // given
-            memberRepository.save(Member.of("test-user-4", null, "TECH"));
+            memberRepository.save(Member.of("test-user-4", "test-name-4", "TECH"));
 
             // when
             Long batchId = batchService.executeBatch(
@@ -185,7 +185,7 @@ class PostingBatchIntegrationTest {
         @DisplayName("[통합] 배치 실행 후 Posting 데이터 생성 확인 [success]")
         void posting_data_created_after_batch() {
             // given
-            memberRepository.save(Member.of("test-user-5", null, "TECH"));
+            memberRepository.save(Member.of("test-user-5", "test-name-5", "TECH"));
 
             // when
             batchService.executeBatch(

--- a/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
@@ -81,7 +81,7 @@ class PostingServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Posting posting = new Posting(1L, startDate, 1, 2, 3, 4, 5, 6, 7, "admin");
         Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
-        Member member = Member.of("testUser", "CAT01");
+        Member member = Member.of("testUser", null, "CAT01");
         ReflectionTestUtils.setField(member, "id", 1L);
 
         when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(null), eq(pageable)))
@@ -109,7 +109,7 @@ class PostingServiceTest {
         Posting posting1 = new Posting(1L, LocalDate.of(2026, 6, 2), 1, 0, 0, 0, 0, 0, 0, "admin");
         Posting posting2 = new Posting(1L, LocalDate.of(2026, 6, 9), 0, 1, 0, 0, 0, 0, 0, "admin");
         Page<Posting> postingPage = new PageImpl<>(List.of(posting1, posting2), pageable, 2);
-        Member member = Member.of("testUser", "CAT01");
+        Member member = Member.of("testUser", null, "CAT01");
         ReflectionTestUtils.setField(member, "id", 1L);
 
         when(postingRepository.findAllBySearchCondition(eq(startDate), eq(endDate), eq(null), eq(pageable)))
@@ -133,7 +133,7 @@ class PostingServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Posting posting = new Posting(memberId, startDate, 3, 3, 3, 3, 3, 3, 3, "admin");
         Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
-        Member member = Member.of("targetUser", "CAT01");
+        Member member = Member.of("targetUser", null, "CAT01");
         ReflectionTestUtils.setField(member, "id", memberId);
 
         when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(memberId), eq(pageable)))

--- a/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
@@ -81,7 +81,7 @@ class PostingServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Posting posting = new Posting(1L, startDate, 1, 2, 3, 4, 5, 6, 7, "admin");
         Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
-        Member member = Member.of("testUser", null, "CAT01");
+        Member member = Member.of("testUser", "test-name", "CAT01");
         ReflectionTestUtils.setField(member, "id", 1L);
 
         when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(null), eq(pageable)))
@@ -109,7 +109,7 @@ class PostingServiceTest {
         Posting posting1 = new Posting(1L, LocalDate.of(2026, 6, 2), 1, 0, 0, 0, 0, 0, 0, "admin");
         Posting posting2 = new Posting(1L, LocalDate.of(2026, 6, 9), 0, 1, 0, 0, 0, 0, 0, "admin");
         Page<Posting> postingPage = new PageImpl<>(List.of(posting1, posting2), pageable, 2);
-        Member member = Member.of("testUser", null, "CAT01");
+        Member member = Member.of("testUser", "test-name", "CAT01");
         ReflectionTestUtils.setField(member, "id", 1L);
 
         when(postingRepository.findAllBySearchCondition(eq(startDate), eq(endDate), eq(null), eq(pageable)))
@@ -133,7 +133,7 @@ class PostingServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Posting posting = new Posting(memberId, startDate, 3, 3, 3, 3, 3, 3, 3, "admin");
         Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
-        Member member = Member.of("targetUser", null, "CAT01");
+        Member member = Member.of("targetUser", "test-name", "CAT01");
         ReflectionTestUtils.setField(member, "id", memberId);
 
         when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(memberId), eq(pageable)))


### PR DESCRIPTION
## Summary
- `member` 테이블에 `name` 컬럼 추가 (Flyway V1.3 마이그레이션)
- 회원 생성/수정 API에서 `name` 필드 수신 및 DB 저장
- MemberRequest → MemberCommand → MemberResult → MemberResponse 전 계층 연동

## 변경 파일

### 소스 코드
| 파일 | 변경 내용 |
|------|----------|
| `Member.java` | `name` 필드 추가, `of()`/`update()` 팩토리 메서드 업데이트 |
| `MemberRequest.java` | `MemberDto`, `MemberCreateDto`에 `name` 추가 (`@NotBlank`, `@Size(max=50)`) |
| `MemberCommand.java` | `Create`, `Update` 커맨드에 `name` 추가 |
| `MemberResult.java` | `Detail`, `Update`, `Summary`에 `name` 추가 |
| `MemberResponse.java` | 응답 DTO 전체에 `name` 추가 |
| `MemberService.java` | create/update 로직에서 `name` 전달 |
| `MemberController.java` | createMember/updateMember에서 `name` 전달 |
| `MemberRepositoryImpl.java` | QueryDSL Projections에 `member.name` 추가 |
| `V1.3__Add_Member_Name_Column.sql` | Flyway 마이그레이션 — name 컬럼 추가 |

### 테스트
- `MemberServiceTest`, `MemberCommandTest`, `MemberControllerTest`
- `MemberControllerIntegrationTest`, `MemberIntegrationTest`
- `PostingServiceTest`, `PostingBatchIntegrationTest`

## Test plan
- [ ] `POST /members` — `name` 필드 포함 회원 생성 정상 동작 확인
- [ ] `PUT /members/{id}` — `name` 필드 포함 회원 수정 정상 동작 확인
- [ ] `GET /members/{id}` — 응답에 `name` 필드 포함 확인
- [ ] Flyway V1.3 마이그레이션 적용 후 `member` 테이블 `name` 컬럼 존재 확인
- [ ] 단위 테스트 전체 통과 (`./gradlew test`)
- [ ] 기존 기능 리그레션 없음 확인

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)