### PR TITLE
#35: 네이버 블로그 해당 날짜 글 없을 시 파싱 오류 수정

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/service/NaverBlogScraper.java
+++ b/src/main/java/com/jk/amazon2/posting/service/NaverBlogScraper.java
@@ -81,8 +81,7 @@ public class NaverBlogScraper {
         Elements categoryTitlePcol2 = doc.getElementsByClass("category_title pcol2");
 
         if (categoryTitlePcol2.isEmpty()) {
-            return new ScrapingResult.Failure<>(ScrapingResult.FailureType.PARSING_ERROR,
-                    "요소를 찾을 수 없음: category_title pcol2", null);
+            return new ScrapingResult.Success<>(0);
         }
 
         Element element = categoryTitlePcol2.get(0);

--- a/src/test/java/com/jk/amazon2/posting/service/NaverBlogScraperTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/NaverBlogScraperTest.java
@@ -31,13 +31,20 @@ class NaverBlogScraperTest {
         // When
         ScrapingResult<Integer> result = scraper.scrapePostingCount(invalidBlogId, date);
 
-        // Then: 네트워크 실패 또는 HTTP 오류 또는 파싱 오류 중 하나
-        assertThat(result).isInstanceOf(ScrapingResult.Failure.class);
-        ScrapingResult.Failure<Integer> failure = (ScrapingResult.Failure<Integer>) result;
-        assertThat(failure.type()).isIn(
-                ScrapingResult.FailureType.NETWORK_ERROR,
-                ScrapingResult.FailureType.HTTP_ERROR,
-                ScrapingResult.FailureType.PARSING_ERROR
+        // Then: 네트워크 실패, HTTP 오류, 또는 글 없음(0) 중 하나
+        // - 블로그가 없거나 해당 날짜에 글이 없으면 category_title pcol2 요소가 없어 Success(0) 반환
+        assertThat(result).satisfiesAnyOf(
+                r -> {
+                    assertThat(r).isInstanceOf(ScrapingResult.Failure.class);
+                    assertThat(((ScrapingResult.Failure<Integer>) r).type()).isIn(
+                            ScrapingResult.FailureType.NETWORK_ERROR,
+                            ScrapingResult.FailureType.HTTP_ERROR
+                    );
+                },
+                r -> {
+                    assertThat(r).isInstanceOf(ScrapingResult.Success.class);
+                    assertThat(((ScrapingResult.Success<Integer>) r).value()).isEqualTo(0);
+                }
         );
     }
 }


### PR DESCRIPTION
## Summary
- `NaverBlogScraper`에서 `category_title pcol2` 요소가 없을 때 `PARSING_ERROR` 대신 `Success(0)` 반환하도록 수정
- 해당 날짜에 작성한 글이 없으면 요소가 렌더링되지 않으므로 0건 정상 처리가 맞음
- `NaverBlogScraperTest` 기대값 업데이트

## Test plan
- [x] `NaverBlogScraperTest` 통과 확인
- [x] 전체 테스트 통과 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)