### PR TITLE
#37: 네이버 블로그 스크래퍼 viewdate 파라미터 형식 오류 수정

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/service/NaverBlogScraper.java
+++ b/src/main/java/com/jk/amazon2/posting/service/NaverBlogScraper.java
@@ -13,6 +13,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,7 +51,7 @@ public class NaverBlogScraper {
 
     private String buildUrl(String blogId, LocalDate date) {
         return String.format("%s?blogId=%s&viewdate=%s",
-            NAVER_BLOG_BASE_URL, blogId, date);
+            NAVER_BLOG_BASE_URL, blogId, date.format(DateTimeFormatter.BASIC_ISO_DATE));
     }
 
     private ScrapingResult<Document> fetchAndParse(String url) throws InterruptedException {


### PR DESCRIPTION
## 개요
배치 실행 시 네이버 블로그 스크래핑 URL의 viewdate 파라미터 형식 오류로 포스팅 수가 항상 0으로 저장되는 버그 수정

## 변경사항
- `NaverBlogScraper.java`: `LocalDate.toString()` → `DateTimeFormatter.BASIC_ISO_DATE` 적용
  - 기존: `2026-06-22` (대시 포함, 네이버 API 미인식)
  - 수정: `20260622` (대시 없음, 네이버 PostList.naver 요구 형식)

## 테스트 방법
- curl로 두 URL 형식 직접 비교 검증
  - `viewdate=2026-06-22` → `category_title pcol2` 미반환
  - `viewdate=20260622` → `category_title pcol2` 정상 반환
- 배치 실행 후 DB count 값 정상 저장 확인

## 체크리스트
- [ ] 단위 테스트 작성/수정 완료
- [ ] CI 테스트 통과
- [ ] 코드 리뷰 요청 완료
- [ ] 문서 업데이트 (필요시)
- [ ] 기존 기능 리그레션 확인

## 관련 이슈
Closes #37