### PR TITLE
#39: viewdate 파라미터 형식 롤백 (2026-06-22 형식 복원)

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/service/NaverBlogScraper.java
+++ b/src/main/java/com/jk/amazon2/posting/service/NaverBlogScraper.java
@@ -13,7 +13,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,7 +50,7 @@ public class NaverBlogScraper {
 
     private String buildUrl(String blogId, LocalDate date) {
         return String.format("%s?blogId=%s&viewdate=%s",
-            NAVER_BLOG_BASE_URL, blogId, date.format(DateTimeFormatter.BASIC_ISO_DATE));
+            NAVER_BLOG_BASE_URL, blogId, date);
     }
 
     private ScrapingResult<Document> fetchAndParse(String url) throws InterruptedException {


### PR DESCRIPTION
## 개요
#38에서 잘못 적용된 viewdate 파라미터 형식 변경을 롤백. 네이버 블로그 PostList.naver는 `2026-06-22` (대시 포함) 형식이 올바름

## 변경사항
- `NaverBlogScraper.java`: `DateTimeFormatter.BASIC_ISO_DATE` 제거, `LocalDate.toString()` 복원
  - 롤백 전: `20260622` (대시 없음)
  - 롤백 후: `2026-06-22` (대시 포함, 정상 동작 확인)

## 테스트 방법
- `viewdate=2026-06-22` 형식으로 네이버 블로그 요청 시 정상 응답 확인

## 체크리스트
- [ ] 단위 테스트 작성/수정 완료
- [ ] CI 테스트 통과
- [ ] 코드 리뷰 요청 완료
- [ ] 문서 업데이트 (필요시)
- [ ] 기존 기능 리그레션 확인

## 관련 이슈
Closes #39