### PR TITLE
#41: Member 단건 API 식별자를 ID에서 Nickname으로 변경

### DIFF
--- a/src/main/java/com/jk/amazon2/member/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/member/controller/MemberController.java
@@ -22,9 +22,9 @@ public class MemberController implements MemberApiSpec {
     private final MemberService memberService;
 
     @Override
-    @GetMapping("/members/{id}")
-    public ResponseEntity<MemberResponse.MemberDetailDto> getMember(@PathVariable Long id) {
-        MemberResult.Detail result = memberService.findById(id);
+    @GetMapping("/members/{nickname}")
+    public ResponseEntity<MemberResponse.MemberDetailDto> getMember(@PathVariable String nickname) {
+        MemberResult.Detail result = memberService.findByNickname(nickname);
         return ResponseEntity.ok(MemberResponse.MemberDetailDto.from(result));
     }
 
@@ -58,12 +58,12 @@ public class MemberController implements MemberApiSpec {
     }
 
     @Override
-    @PutMapping("/members/{id}")
+    @PutMapping("/members/{nickname}")
     public ResponseEntity<MemberResponse.MemberUpdateDto> updateMember(
-            @PathVariable Long id,
+            @PathVariable String nickname,
             @RequestBody MemberRequest.MemberDto member
     ) {
-        var update = MemberCommand.Update.of(id, member.nickname(), member.name(), member.categoryCode());
+        var update = MemberCommand.Update.of(nickname, member.nickname(), member.name(), member.categoryCode());
 
         var response = MemberResponse.MemberUpdateDto.from(memberService.update(update));
         return ResponseEntity
@@ -72,22 +72,22 @@ public class MemberController implements MemberApiSpec {
     }
 
     @Override
-    @DeleteMapping("/members/{id}")
+    @DeleteMapping("/members/{nickname}")
     public ResponseEntity<Void> deleteMember(
-            @PathVariable Long id
+            @PathVariable String nickname
     ) {
-        memberService.delete(id);
+        memberService.delete(nickname);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();
     }
 
     @Override
-    @DeleteMapping("/members/{id}/permanent")
+    @DeleteMapping("/members/{nickname}/permanent")
     public ResponseEntity<Void> hardDeleteMember(
-            @PathVariable Long id
+            @PathVariable String nickname
     ) {
-        memberService.hardDelete(id);
+        memberService.hardDelete(nickname);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();

--- a/src/main/java/com/jk/amazon2/member/controller/spec/MemberApiSpec.java
+++ b/src/main/java/com/jk/amazon2/member/controller/spec/MemberApiSpec.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 public interface MemberApiSpec {
     @Operation(summary = "유저 단건 조회")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    ResponseEntity<MemberResponse.MemberDetailDto> getMember(Long id);
+    ResponseEntity<MemberResponse.MemberDetailDto> getMember(String nickname);
     @Operation(summary = "유저 조회 및 검색")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     ResponseEntity<Page<MemberResponse.MemberListDto>> getMembers(
@@ -26,11 +26,11 @@ public interface MemberApiSpec {
     ResponseEntity<MemberResponse.MemberCreateDto> createMember(MemberRequest.MemberCreateDto memberDto);
     @Operation(summary = "유저 수정")
     @ApiResponse(responseCode = "200", description = "유저 수정 성공")
-    ResponseEntity<MemberResponse.MemberUpdateDto> updateMember(Long id, MemberRequest.MemberDto memberDto);
+    ResponseEntity<MemberResponse.MemberUpdateDto> updateMember(String nickname, MemberRequest.MemberDto memberDto);
     @Operation(summary = "유저 삭제")
     @ApiResponse(responseCode = "204", description = "유저 삭제 성공")
-    ResponseEntity<Void> deleteMember(Long memberId);
+    ResponseEntity<Void> deleteMember(String nickname);
     @Operation(summary = "유저 영구 삭제")
     @ApiResponse(responseCode = "204", description = "유저 영구 삭제 성공")
-    ResponseEntity<Void> hardDeleteMember(Long memberId);
+    ResponseEntity<Void> hardDeleteMember(String nickname);
 }

--- a/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
@@ -46,16 +46,20 @@ public class MemberCommand {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Update {
 
-        private Long id;
+        private String currentNickname;
         private String nickname;
         private String name;
         private String categoryCode;
 
-        public static Update of(Long id, String nickname, String name, String categoryCode) {
-            return new Update(id, nickname, name, categoryCode);
+        public static Update of(String currentNickname, String nickname, String name, String categoryCode) {
+            return new Update(currentNickname, nickname, name, categoryCode);
         }
 
-        private Update(Long id, String nickname, String name, String categoryCode) {
+        private Update(String currentNickname, String nickname, String name, String categoryCode) {
+            if (currentNickname == null || currentNickname.isBlank()) {
+                log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid currentNickname. currentNickname={}", currentNickname);
+                throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
+            }
             if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid nickname. nickname={}", nickname);
                 throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
@@ -69,7 +73,7 @@ public class MemberCommand {
                 throw new RestApiException(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID);
             }
 
-            this.id = id;
+            this.currentNickname = currentNickname;
             this.nickname = nickname;
             this.name = name;
             this.categoryCode = categoryCode;

--- a/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
@@ -3,6 +3,9 @@ package com.jk.amazon2.member.repository;
 import com.jk.amazon2.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     boolean existsByNickname(String nickname);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/jk/amazon2/member/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/member/service/MemberService.java
@@ -41,7 +41,7 @@ public class MemberService {
     @Transactional
     public MemberResult.Update update(MemberCommand.Update command) {
         Member member = memberRepository
-                .findById(command.getId())
+                .findByNickname(command.getCurrentNickname())
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         categoryValidationPort.validateCategoryExists(command.getCategoryCode());
@@ -51,15 +51,15 @@ public class MemberService {
     }
 
     @Transactional
-    public void delete(Long id) {
-        Member member = memberRepository.findById(id)
+    public void delete(String nickname) {
+        Member member = memberRepository.findByNickname(nickname)
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
         member.softDelete();
     }
 
     @Transactional(readOnly = true)
-    public MemberResult.Detail findById(Long id) {
-        Member member = memberRepository.findById(id)
+    public MemberResult.Detail findByNickname(String nickname) {
+        Member member = memberRepository.findByNickname(nickname)
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
         return MemberResult.Detail.from(member);
     }
@@ -71,8 +71,8 @@ public class MemberService {
     }
 
     @Transactional
-    public void hardDelete(Long id) {
-        Member member = memberRepository.findById(id)
+    public void hardDelete(String nickname) {
+        Member member = memberRepository.findByNickname(nickname)
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
         if (!member.isDeleted()) {
             throw new RestApiException(MemberErrorCode.MEMBER_NOT_DELETED);

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
@@ -67,7 +67,7 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
                     .willReturn(updateResult);
 
             // when & then
-            mockMvc.perform(put("/members/{id}", memberId)
+            mockMvc.perform(put("/members/{nickname}", nickname)
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -81,7 +81,6 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         @DisplayName("회원 수정 성공 - categoryCode null [success]")
         void updateMember_success_with_null_categoryCode() throws Exception {
             // given
-            Long memberId = 1L;
             String nickname = "updated_member";
 
             MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", null);
@@ -91,7 +90,7 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
                     .willReturn(updateResult);
 
             // when & then
-            mockMvc.perform(put("/members/{id}", memberId)
+            mockMvc.perform(put("/members/{nickname}", nickname)
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -105,14 +104,13 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         @MethodSource("provideUpdateMemberFailureCases")
         void updateMember_fail(String scenario, String nickname, String categoryCode, MemberErrorCode errorCode) throws Exception {
             // given
-            Long memberId = 1L;
             MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", categoryCode);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willThrow(new RestApiException(errorCode));
 
             // when & then
-            mockMvc.perform(put("/members/{id}", memberId)
+            mockMvc.perform(put("/members/{nickname}", "test_member")
                             .contentType(APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().is4xxClientError());
@@ -295,25 +293,25 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         @DisplayName("회원 영구 삭제 성공 [success]")
         void hardDeleteMember_success() throws Exception {
             // given
-            Long memberId = 1L;
+            String nickname = "test_member";
 
             // when & then
-            mockMvc.perform(delete("/members/{id}/permanent", memberId))
+            mockMvc.perform(delete("/members/{nickname}/permanent", nickname))
                     .andExpect(status().isNoContent());
 
-            verify(memberService).hardDelete(memberId);
+            verify(memberService).hardDelete(nickname);
         }
 
         @Test
         @DisplayName("회원 영구 삭제 실패 - 소프트 삭제되지 않은 회원 [fail]")
         void hardDeleteMember_fail_not_deleted() throws Exception {
             // given
-            Long memberId = 1L;
+            String nickname = "test_member";
             org.mockito.Mockito.doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_DELETED))
-                    .when(memberService).hardDelete(memberId);
+                    .when(memberService).hardDelete(nickname);
 
             // when & then
-            mockMvc.perform(delete("/members/{id}/permanent", memberId))
+            mockMvc.perform(delete("/members/{nickname}/permanent", nickname))
                     .andExpect(status().isBadRequest());
         }
     }

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
@@ -73,7 +74,6 @@ class MemberControllerTest {
             // given
             var request = new MemberRequest.MemberCreateDto(nickname, "test-name", categoryCode);
 
-            // 서비스 로직 에러인 경우에만 Mocking (유효성 검사 실패는 서비스 호출 전 발생)
             if (errorCode == MemberErrorCode.MEMBER_NICKNAME_ALREADY_EXISTS || errorCode == CategoryErrorCode.CATEGORY_NOT_FOUND) {
                 given(memberService.create(any(MemberCommand.Create.class)))
                         .willThrow(new RestApiException(errorCode));
@@ -103,26 +103,26 @@ class MemberControllerTest {
         @DisplayName("회원 삭제 성공")
         void deleteMember_success() {
             // given
-            Long id = 1L;
+            String nickname = "test_member";
 
             // when
-            ResponseEntity<Void> response = memberController.deleteMember(id);
+            ResponseEntity<Void> response = memberController.deleteMember(nickname);
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.NO_CONTENT);
-            verify(memberService).delete(id);
+            verify(memberService).delete(nickname);
         }
 
         @Test
-        @DisplayName("회원 삭제 실패 - 존재하지 않는 회원")
+        @DisplayName("회원 삭제 실패 - 존재하지 않는 닉네임")
         void deleteMember_fail_not_found() {
             // given
-            Long id = 999L;
-            org.mockito.Mockito.doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND))
-                    .when(memberService).delete(id);
+            String nickname = "non_existent";
+            Mockito.doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND))
+                    .when(memberService).delete(nickname);
 
             // when & then
-            assertThatThrownBy(() -> memberController.deleteMember(id))
+            assertThatThrownBy(() -> memberController.deleteMember(nickname))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
@@ -132,36 +132,37 @@ class MemberControllerTest {
     @DisplayName("Member 조회 - 단위 테스트")
     class GetMember {
         @Test
-        @DisplayName("회원 조회 성공")
+        @DisplayName("닉네임으로 회원 조회 성공")
         void getMember_success() {
             // given
             Long id = 1L;
-            var result = MemberResult.Detail.of(id, "test_member", "test-name", "DEV", LocalDateTime.now(), false);
-            given(memberService.findById(id))
+            String nickname = "test_member";
+            var result = MemberResult.Detail.of(id, nickname, "test-name", "DEV", LocalDateTime.now(), false);
+            given(memberService.findByNickname(nickname))
                     .willReturn(result);
 
             // when
-            ResponseEntity<MemberResponse.MemberDetailDto> response = memberController.getMember(id);
+            ResponseEntity<MemberResponse.MemberDetailDto> response = memberController.getMember(nickname);
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();
             assertThat(response.getBody().id()).isEqualTo(id);
-            assertThat(response.getBody().nickname()).isEqualTo("test_member");
+            assertThat(response.getBody().nickname()).isEqualTo(nickname);
             assertThat(response.getBody().categoryCode()).isEqualTo("DEV");
             assertThat(response.getBody().status()).isEqualTo("active");
         }
 
         @Test
-        @DisplayName("회원 조회 실패 - 존재하지 않는 회원")
+        @DisplayName("닉네임으로 회원 조회 실패 - 존재하지 않는 닉네임")
         void getMember_fail_not_found() {
             // given
-            Long id = 999L;
-            given(memberService.findById(id))
+            String nickname = "non_existent";
+            given(memberService.findByNickname(nickname))
                     .willThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
             // when & then
-            assertThatThrownBy(() -> memberController.getMember(id))
+            assertThatThrownBy(() -> memberController.getMember(nickname))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
@@ -174,29 +175,28 @@ class MemberControllerTest {
         @DisplayName("회원 영구 삭제 성공")
         void hardDeleteMember_success() {
             // given
-            Long id = 1L;
+            String nickname = "test_member";
 
             // when
-            ResponseEntity<Void> response = memberController.hardDeleteMember(id);
+            ResponseEntity<Void> response = memberController.hardDeleteMember(nickname);
 
             // then
             assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.NO_CONTENT);
-            verify(memberService).hardDelete(id);
+            verify(memberService).hardDelete(nickname);
         }
 
         @Test
         @DisplayName("회원 영구 삭제 실패 - 소프트 삭제되지 않은 회원")
         void hardDeleteMember_fail_not_deleted() {
             // given
-            Long id = 1L;
+            String nickname = "test_member";
             doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_DELETED))
-                    .when(memberService).hardDelete(id);
+                    .when(memberService).hardDelete(nickname);
 
             // when & then
-            assertThatThrownBy(() -> memberController.hardDeleteMember(id))
+            assertThatThrownBy(() -> memberController.hardDeleteMember(nickname))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_DELETED.getMessage());
         }
     }
-
 }

--- a/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
@@ -11,18 +11,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
 import java.util.Locale;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,7 +45,6 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         @Test
         void createMember_Integration_Success() {
             // given
-            // 1. 카테고리 미리 생성
             String categoryCode = "DEV_TEST";
             String categoryName = "개발";
             String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
@@ -61,7 +55,6 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             }
 
             String nickname = faker.name().fullName();
-            // 닉네임 길이 제한(50자)에 맞게 자르기
             if (nickname.length() > 50) nickname = nickname.substring(0, 50);
 
             var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
@@ -123,17 +116,8 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         @org.junit.jupiter.api.Disabled("카테고리 검증 부분 수정 필요 - 별도 PR에서 해결")
         void createMember_Integration_Fail_CategoryNotFound() {
             // given
-            // 카테고리 10자 이상 코드는 검증 에러가 발생하므로, 10자 이하로 설정
             String categoryCode = "UNKNOWN";
-            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertCategorySql, "VALID_CAT", "유효한카테고리", "설명");
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
-
             String nickname = "new_user";
-            // 존재하지 않는 카테고리 코드 (10자 이하)
             var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
 
             // when & then
@@ -164,7 +148,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             }
         }
 
-        @DisplayName("[통합] GET /members/{id} - 회원 단건 조회 성공 [200 OK]")
+        @DisplayName("[통합] GET /members/{nickname} - 회원 단건 조회 성공 [200 OK]")
         @Test
         void getMember_Integration_Success() {
             // given
@@ -172,14 +156,11 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
             jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
 
-            String selectIdSql = "SELECT id FROM member WHERE nickname = ?";
-            Long memberId = jdbcTemplate.queryForObject(selectIdSql, Long.class, nickname);
-
             // when & then
             RestAssuredMockMvc
                     .given()
                     .when()
-                    .get("/members/{id}", memberId)
+                    .get("/members/{nickname}", nickname)
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("nickname", equalTo(nickname))
@@ -264,16 +245,13 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             }
         }
 
-        @DisplayName("[통합] PUT /members/{id} - 회원 수정 성공 [200 OK]")
+        @DisplayName("[통합] PUT /members/{nickname} - 회원 수정 성공 [200 OK]")
         @Test
         void updateMember_Integration_Success() {
             // given
             String nickname = "original_user";
             String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
             jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
-
-            String selectIdSql = "SELECT id FROM member WHERE nickname = ?";
-            Long memberId = jdbcTemplate.queryForObject(selectIdSql, Long.class, nickname);
 
             String updatedNickname = "updated_user";
             String updatedCategoryCode = "DESIGN";
@@ -285,7 +263,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     .contentType(ContentType.JSON)
                     .body(requestDto)
                     .when()
-                    .put("/members/{id}", memberId)
+                    .put("/members/{nickname}", nickname)
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("nickname", equalTo(updatedNickname))
@@ -308,7 +286,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             }
         }
 
-        @DisplayName("[통합] DELETE /members/{id} - 회원 소프트 삭제 성공 [204 No Content]")
+        @DisplayName("[통합] DELETE /members/{nickname} - 회원 소프트 삭제 성공 [204 No Content]")
         @Test
         void deleteMember_Integration_Success() {
             // given
@@ -316,25 +294,22 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
             jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
 
-            String selectIdSql = "SELECT id FROM member WHERE nickname = ?";
-            Long memberId = jdbcTemplate.queryForObject(selectIdSql, Long.class, nickname);
-
             // when & then
             RestAssuredMockMvc
                     .given()
                     .when()
-                    .delete("/members/{id}", memberId)
+                    .delete("/members/{nickname}", nickname)
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
-            // DB 검증 - deleted = true (flush 후 확인)
+            // DB 검증 - deleted = true (JPA flush 후 확인)
             em.flush();
-            String selectDeletedSql = "SELECT deleted FROM member WHERE id = ?";
-            Boolean deleted = jdbcTemplate.queryForObject(selectDeletedSql, Boolean.class, memberId);
+            String selectDeletedSql = "SELECT deleted FROM member WHERE nickname = ?";
+            Boolean deleted = jdbcTemplate.queryForObject(selectDeletedSql, Boolean.class, nickname);
             assertThat(deleted).isTrue();
         }
 
-        @DisplayName("[통합] DELETE /members/{id}/permanent - 회원 영구 삭제 성공 [204 No Content]")
+        @DisplayName("[통합] DELETE /members/{nickname}/permanent - 회원 영구 삭제 성공 [204 No Content]")
         @Test
         void hardDeleteMember_Integration_Success() {
             // given
@@ -342,25 +317,22 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, ?, NOW(), 'system', NOW(), 'system')";
             jdbcTemplate.update(insertMemberSql, nickname, categoryCode, true);
 
-            String selectIdSql = "SELECT id FROM member WHERE nickname = ?";
-            Long memberId = jdbcTemplate.queryForObject(selectIdSql, Long.class, nickname);
-
             // when & then
             RestAssuredMockMvc
                     .given()
                     .when()
-                    .delete("/members/{id}/permanent", memberId)
+                    .delete("/members/{nickname}/permanent", nickname)
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
-            // DB 검증 - 완전 삭제 (flush 후 확인)
+            // DB 검증 - 완전 삭제 (JPA flush 후 확인)
             em.flush();
-            String selectSql = "SELECT count(*) FROM member WHERE id = ?";
-            Integer count = jdbcTemplate.queryForObject(selectSql, Integer.class, memberId);
+            String selectSql = "SELECT count(*) FROM member WHERE nickname = ?";
+            Integer count = jdbcTemplate.queryForObject(selectSql, Integer.class, nickname);
             assertThat(count).isEqualTo(0);
         }
 
-        @DisplayName("[통합] DELETE /members/{id}/permanent - 소프트 삭제되지 않은 회원 영구 삭제 실패 [400 Bad Request]")
+        @DisplayName("[통합] DELETE /members/{nickname}/permanent - 소프트 삭제되지 않은 회원 영구 삭제 실패 [400 Bad Request]")
         @Test
         void hardDeleteMember_Integration_Fail_NotDeleted() {
             // given
@@ -368,14 +340,11 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
             jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
 
-            String selectIdSql = "SELECT id FROM member WHERE nickname = ?";
-            Long memberId = jdbcTemplate.queryForObject(selectIdSql, Long.class, nickname);
-
             // when & then
             RestAssuredMockMvc
                     .given()
                     .when()
-                    .delete("/members/{id}/permanent", memberId)
+                    .delete("/members/{nickname}/permanent", nickname)
                     .then()
                     .statusCode(HttpStatus.BAD_REQUEST.value())
                     .body("code", equalTo(MemberErrorCode.MEMBER_NOT_DELETED.name()));

--- a/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -42,13 +41,12 @@ class MemberServiceTest {
     @BeforeEach
     void setUp() {
         memberService = new MemberService(memberRepository, categoryValidationPort);
-
     }
 
     @Nested
     @DisplayName("Member 생성 - 단위 테스트")
     class CreateMember {
-        @DisplayName("유저 생성 시, 일력된 정보가 엔티티로 변환되어 저장 [success]")
+        @DisplayName("유저 생성 시, 입력된 정보가 엔티티로 변환되어 저장 [success]")
         @Test
         void member_create_success() {
             // given
@@ -74,14 +72,13 @@ class MemberServiceTest {
 
             // then
             assertThat(savedMember).isNotNull();
-            SoftAssertions.assertSoftly(softly ->{
+            SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(savedMember.getNickname()).isEqualTo(nickname);
                 softly.assertThat(savedMember.getName()).isEqualTo(name);
                 softly.assertThat(savedMember.getCategoryCode()).isEqualTo(categoryCode);
                 softly.assertThat(savedMember.getId()).isEqualTo(id);
             });
 
-            // Verify Service Call
             ArgumentCaptor<Member> commandCaptor = ArgumentCaptor.forClass(Member.class);
             verify(memberRepository).save(commandCaptor.capture());
             Member capturedCommand = commandCaptor.getValue();
@@ -136,15 +133,14 @@ class MemberServiceTest {
         @Test
         void update_success() {
             // given
-            Long id = 1L;
+            String currentNickname = "test_member";
             String newNickname = "updated_member";
             String newName = "updated-name";
             String newCategoryCode = "UPDATED";
-            Member member = Member.of("test_member", "test-name", "DEV");
-            ReflectionTestUtils.setField(member, "id", id);
+            Member member = Member.of(currentNickname, "test-name", "DEV");
 
-            var updateCommand = MemberCommand.Update.of(id, newNickname, newName, newCategoryCode);
-            given(memberRepository.findById(id))
+            var updateCommand = MemberCommand.Update.of(currentNickname, newNickname, newName, newCategoryCode);
+            given(memberRepository.findByNickname(currentNickname))
                     .willReturn(Optional.of(member));
 
             // when
@@ -159,16 +155,14 @@ class MemberServiceTest {
             verify(categoryValidationPort).validateCategoryExists(newCategoryCode);
         }
 
-        @DisplayName("회원 업데이트 실패 - 존재하지 않는 회원 [fail]")
+        @DisplayName("회원 업데이트 실패 - 존재하지 않는 닉네임 [fail]")
         @Test
         void update_fail_not_found() {
             // given
-            Long id = 999L;
-            String newNickname = "updated_member";
-            String newCategoryCode = "UPDATED";
-            var updateCommand = MemberCommand.Update.of(id, newNickname, "updated-name", newCategoryCode);
+            String currentNickname = "non_existent";
+            var updateCommand = MemberCommand.Update.of(currentNickname, "updated_member", "updated-name", "UPDATED");
 
-            given(memberRepository.findById(id))
+            given(memberRepository.findByNickname(currentNickname))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -181,14 +175,12 @@ class MemberServiceTest {
         @Test
         void update_fail_category_not_found() {
             // given
-            Long id = 1L;
-            String newNickname = "updated_member";
+            String currentNickname = "test_member";
             String newCategoryCode = "NOTEXIST";
-            Member member = Member.of("test_member", "test-name", "DEV");
-            ReflectionTestUtils.setField(member, "id", id);
-            var updateCommand = MemberCommand.Update.of(id, newNickname, "updated-name", newCategoryCode);
+            Member member = Member.of(currentNickname, "test-name", "DEV");
+            var updateCommand = MemberCommand.Update.of(currentNickname, "updated_member", "updated-name", newCategoryCode);
 
-            given(memberRepository.findById(id))
+            given(memberRepository.findByNickname(currentNickname))
                     .willReturn(Optional.of(member));
             doThrow(new RestApiException(CategoryErrorCode.CATEGORY_NOT_FOUND))
                     .when(categoryValidationPort).validateCategoryExists(newCategoryCode);
@@ -207,14 +199,13 @@ class MemberServiceTest {
         @DisplayName("회원 삭제 성공 [success]")
         void delete_success() {
             // given
-            Long id = 1L;
-            Member member = Member.of("test_member", "test-name", "DEV");
-            ReflectionTestUtils.setField(member, "id", id);
-            given(memberRepository.findById(id))
+            String nickname = "test_member";
+            Member member = Member.of(nickname, "test-name", "DEV");
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.of(member));
 
             // when
-            memberService.delete(id);
+            memberService.delete(nickname);
 
             // then
             assertThat(member.isDeleted()).isTrue();
@@ -224,30 +215,29 @@ class MemberServiceTest {
         @DisplayName("이미 삭제된 회원 재삭제 성공 - 멱등성 [success]")
         void delete_success_already_deleted() {
             // given
-            Long id = 1L;
-            Member member = Member.of("test_member", "test-name", "DEV");
-            ReflectionTestUtils.setField(member, "id", id);
+            String nickname = "test_member";
+            Member member = Member.of(nickname, "test-name", "DEV");
             member.softDelete();
-            given(memberRepository.findById(id))
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.of(member));
 
             // when
-            memberService.delete(id);
+            memberService.delete(nickname);
 
             // then
             assertThat(member.isDeleted()).isTrue();
         }
 
         @Test
-        @DisplayName("회원 삭제 실패 - 존재하지 않는 회원 [fail]")
+        @DisplayName("회원 삭제 실패 - 존재하지 않는 닉네임 [fail]")
         void delete_fail_not_found() {
             // given
-            Long id = 999L;
-            given(memberRepository.findById(id))
+            String nickname = "non_existent";
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> memberService.delete(id))
+            assertThatThrownBy(() -> memberService.delete(nickname))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
@@ -257,38 +247,39 @@ class MemberServiceTest {
     @DisplayName("Member 조회 - 단위 테스트")
     class GetMember {
         @Test
-        @DisplayName("회원 조회 성공 [success]")
-        void findById_success() {
+        @DisplayName("닉네임으로 회원 조회 성공 [success]")
+        void findByNickname_success() {
             // given
             Long id = 1L;
-            Member member = Member.of("test_member", "test-name", "DEV");
+            String nickname = "test_member";
+            Member member = Member.of(nickname, "test-name", "DEV");
             ReflectionTestUtils.setField(member, "id", id);
-            given(memberRepository.findById(id))
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.of(member));
 
             // when
-            MemberResult.Detail result = memberService.findById(id);
+            MemberResult.Detail result = memberService.findByNickname(nickname);
 
             // then
             assertThat(result).isNotNull();
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(result.getId()).isEqualTo(id);
-                softly.assertThat(result.getNickname()).isEqualTo("test_member");
+                softly.assertThat(result.getNickname()).isEqualTo(nickname);
                 softly.assertThat(result.getCategoryCode()).isEqualTo("DEV");
                 softly.assertThat(result.isDeleted()).isFalse();
             });
         }
 
         @Test
-        @DisplayName("회원 조회 실패 - 존재하지 않는 회원 [fail]")
-        void findById_fail_not_found() {
+        @DisplayName("닉네임으로 회원 조회 실패 - 존재하지 않는 닉네임 [fail]")
+        void findByNickname_fail_not_found() {
             // given
-            Long id = 999L;
-            given(memberRepository.findById(id))
+            String nickname = "non_existent";
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> memberService.findById(id))
+            assertThatThrownBy(() -> memberService.findByNickname(nickname))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
@@ -301,30 +292,29 @@ class MemberServiceTest {
         @DisplayName("회원 영구 삭제 성공 [success]")
         void hardDelete_success() {
             // given
-            Long id = 1L;
-            Member member = Member.of("test_member", "test-name", "DEV");
-            ReflectionTestUtils.setField(member, "id", id);
+            String nickname = "test_member";
+            Member member = Member.of(nickname, "test-name", "DEV");
             member.softDelete();
-            given(memberRepository.findById(id))
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.of(member));
 
             // when
-            memberService.hardDelete(id);
+            memberService.hardDelete(nickname);
 
             // then
             verify(memberRepository).delete(member);
         }
 
         @Test
-        @DisplayName("회원 영구 삭제 실패 - 존재하지 않는 회원 [fail]")
+        @DisplayName("회원 영구 삭제 실패 - 존재하지 않는 닉네임 [fail]")
         void hardDelete_fail_not_found() {
             // given
-            Long id = 999L;
-            given(memberRepository.findById(id))
+            String nickname = "non_existent";
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> memberService.hardDelete(id))
+            assertThatThrownBy(() -> memberService.hardDelete(nickname))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
         }
@@ -333,14 +323,13 @@ class MemberServiceTest {
         @DisplayName("회원 영구 삭제 실패 - 소프트 삭제되지 않은 회원 [fail]")
         void hardDelete_fail_not_deleted() {
             // given
-            Long id = 1L;
-            Member member = Member.of("test_member", "test-name", "DEV");
-            ReflectionTestUtils.setField(member, "id", id);
-            given(memberRepository.findById(id))
+            String nickname = "test_member";
+            Member member = Member.of(nickname, "test-name", "DEV");
+            given(memberRepository.findByNickname(nickname))
                     .willReturn(Optional.of(member));
 
             // when & then
-            assertThatThrownBy(() -> memberService.hardDelete(id))
+            assertThatThrownBy(() -> memberService.hardDelete(nickname))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NOT_DELETED.getMessage());
         }

--- a/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
@@ -107,7 +107,7 @@ class MemberCommandTest {
                 String categoryCode
         ) {
             // when
-            MemberCommand.Update command = MemberCommand.Update.of(1L, nickname, null, categoryCode);
+            MemberCommand.Update command = MemberCommand.Update.of("currentNickname", nickname, null, categoryCode);
 
             // then
             assertThat(command).isNotNull();
@@ -134,7 +134,7 @@ class MemberCommandTest {
                 String categoryCode
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of(1L, invalidNickname, null, categoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", invalidNickname, null, categoryCode))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
         }
@@ -157,7 +157,7 @@ class MemberCommandTest {
                 String invalidCategoryCode
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of(1L, nickname, null, invalidCategoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", nickname, null, invalidCategoryCode))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID.getMessage());
         }
@@ -174,7 +174,7 @@ class MemberCommandTest {
         @DisplayName("name이 20자를 초과하면 수정 실패 [fail]")
         void update_fail_invalid_name() {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of(1L, "tester", "a".repeat(21), "DEV"))
+            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", "tester", "a".repeat(21), "DEV"))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID.getMessage());
         }
@@ -183,7 +183,7 @@ class MemberCommandTest {
         @DisplayName("name이 null이면 수정 성공 (선택값) [success]")
         void update_success_name_null() {
             // when
-            MemberCommand.Update command = MemberCommand.Update.of(1L, "tester", null, "DEV");
+            MemberCommand.Update command = MemberCommand.Update.of("currentNickname", "tester", null, "DEV");
 
             // then
             assertThat(command.getName()).isNull();


### PR DESCRIPTION
## Summary

- 화면에서 내부 DB ID를 URL에 노출하는 IDOR 보안 취약점 개선
- GET/PUT/DELETE /members/{id} → /members/{nickname} 으로 전면 교체
- nickname은 UNIQUE 제약으로 식별자로 충분히 안전

## 변경 내용

| 레이어 | 변경 내용 |
|--------|-----------|
| Controller | `@PathVariable Long id` → `@PathVariable String nickname` |
| ApiSpec | 메서드 시그니처 변경 |
| Command | `Update.id` 제거, `Update.currentNickname` 추가 |
| Service | `findById`, `update`, `delete`, `hardDelete` → nickname 기반 |
| Repository | `findByNickname()` 추가 |
| 테스트 5개 | nickname 기반으로 전면 수정 |

## Test plan

- [x] 단위 테스트 통과 (MemberServiceTest, MemberControllerTest, MemberCommandTest)
- [x] 통합 테스트 통과 (MemberControllerIntegrationTest, MemberIntegrationTest)
- [x] 기존 id 기반 엔드포인트 완전 제거 확인

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)