### PR TITLE
#46: Feat: GET /postings 응답에 memberName 필드 추가

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
+++ b/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
@@ -8,6 +8,7 @@ public class PostingResponse {
     public record PostingDto(
             Long memberId,
             String memberNickname,
+            String memberName,
             LocalDate weekStartDate,
             int mon,
             int tue,
@@ -17,10 +18,11 @@ public class PostingResponse {
             int sat,
             int sun
     ) {
-        public static PostingDto from(Posting posting, String memberNickname) {
+        public static PostingDto from(Posting posting, String memberNickname, String memberName) {
             return new PostingDto(
                 posting.getMemberId(),
                 memberNickname,
+                memberName,
                 posting.getWeekStartDate(),
                 posting.getMon(),
                 posting.getTue(),

--- a/src/main/java/com/jk/amazon2/posting/service/PostingService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/PostingService.java
@@ -40,10 +40,17 @@ public class PostingService {
             .map(Posting::getMemberId)
             .collect(Collectors.toSet());
 
-        Map<Long, String> nicknameMap = memberRepository.findAllById(memberIds).stream()
-            .collect(Collectors.toMap(Member::getId, Member::getNickname));
+        Map<Long, Member> memberMap = memberRepository.findAllById(memberIds).stream()
+            .collect(Collectors.toMap(Member::getId, m -> m));
 
-        return postings.map(p -> PostingResponse.PostingDto.from(p, nicknameMap.get(p.getMemberId())));
+        return postings.map(p -> {
+            Member member = memberMap.get(p.getMemberId());
+            return PostingResponse.PostingDto.from(
+                p,
+                member != null ? member.getNickname() : null,
+                member != null ? member.getName() : null
+            );
+        });
     }
 
     @Transactional(isolation = Isolation.SERIALIZABLE)

--- a/src/test/java/com/jk/amazon2/posting/integration/PostingServiceIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/posting/integration/PostingServiceIntegrationTest.java
@@ -69,6 +69,7 @@ class PostingServiceIntegrationTest {
         // Then
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).memberNickname()).isEqualTo("active-user");
+        assertThat(result.getContent().get(0).memberName()).isEqualTo("활성멤버");
     }
 
     @Test
@@ -92,5 +93,8 @@ class PostingServiceIntegrationTest {
         assertThat(result.getContent())
             .extracting(PostingResponse.PostingDto::memberNickname)
             .containsExactlyInAnyOrder("user-a", "user-b");
+        assertThat(result.getContent())
+            .extracting(PostingResponse.PostingDto::memberName)
+            .containsExactlyInAnyOrder("멤버A", "멤버B");
     }
 }

--- a/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
@@ -96,6 +96,7 @@ class PostingServiceTest {
         PostingResponse.PostingDto dto = result.getContent().get(0);
         assertThat(dto.weekStartDate()).isEqualTo(startDate);
         assertThat(dto.memberNickname()).isEqualTo("testUser");
+        assertThat(dto.memberName()).isEqualTo("test-name");
         verify(postingRepository).findAllBySearchCondition(startDate, startDate, null, pageable);
     }
 
@@ -147,6 +148,7 @@ class PostingServiceTest {
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).memberId()).isEqualTo(memberId);
         assertThat(result.getContent().get(0).memberNickname()).isEqualTo("targetUser");
+        assertThat(result.getContent().get(0).memberName()).isEqualTo("test-name");
         verify(postingRepository).findAllBySearchCondition(startDate, startDate, memberId, pageable);
     }
 


### PR DESCRIPTION
## 개요

GET /postings 응답에 `memberName` 필드를 추가합니다.

프론트엔드에서 멤버 이름 표시를 위해 `/members` API를 별도 호출해야 했던 문제를 해결합니다.

## 변경 사항

- `PostingResponse.PostingDto`에 `memberName` 필드 추가
- `PostingService.getPostings()`에서 기존 member 조회 결과를 재활용하여 **추가 DB 쿼리 없이** name 매핑
- 관련 단위/통합 테스트 검증 추가

## 응답 변경 전/후

**Before**
```json
{
  "memberId": 1,
  "memberNickname": "jk",
  "weekStartDate": "2026-06-16"
}
```

**After**
```json
{
  "memberId": 1,
  "memberNickname": "jk",
  "memberName": "jk",
  "weekStartDate": "2026-06-16"
}
```

## 체크리스트

- [x] 단위 테스트 작성 (PostingServiceTest)
- [x] 통합 테스트 통과 (PostingServiceIntegrationTest)
- [x] 추가 DB 쿼리 없음 (기존 memberRepository.findAllById 재활용)
- [ ] 코드 리뷰 요청
- [ ] 리그레션 확인

Closes #46