### PR TITLE
#48: Fix: GET /postings 조회 시 포스팅 없는 멤버도 0으로 반환

### DIFF
--- a/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
@@ -1,11 +1,18 @@
 package com.jk.amazon2.member.repository;
 
 import com.jk.amazon2.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     boolean existsByNickname(String nickname);
     Optional<Member> findByNickname(String nickname);
+
+    @Query("SELECT m FROM Member m WHERE m.deleted = false AND (:memberId IS NULL OR m.id = :memberId)")
+    Page<Member> findActiveMembers(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
+++ b/src/main/java/com/jk/amazon2/posting/dto/PostingResponse.java
@@ -1,5 +1,6 @@
 package com.jk.amazon2.posting.dto;
 
+import com.jk.amazon2.member.entity.Member;
 import com.jk.amazon2.posting.entity.Posting;
 
 import java.time.LocalDate;
@@ -18,19 +19,19 @@ public class PostingResponse {
             int sat,
             int sun
     ) {
-        public static PostingDto from(Posting posting, String memberNickname, String memberName) {
+        public static PostingDto from(Member member, Posting posting, LocalDate weekStartDate) {
             return new PostingDto(
-                posting.getMemberId(),
-                memberNickname,
-                memberName,
-                posting.getWeekStartDate(),
-                posting.getMon(),
-                posting.getTue(),
-                posting.getWed(),
-                posting.getThu(),
-                posting.getFri(),
-                posting.getSat(),
-                posting.getSun()
+                member.getId(),
+                member.getNickname(),
+                member.getName(),
+                posting != null ? posting.getWeekStartDate() : weekStartDate,
+                posting != null ? posting.getMon() : 0,
+                posting != null ? posting.getTue() : 0,
+                posting != null ? posting.getWed() : 0,
+                posting != null ? posting.getThu() : 0,
+                posting != null ? posting.getFri() : 0,
+                posting != null ? posting.getSat() : 0,
+                posting != null ? posting.getSun() : 0
             );
         }
     }

--- a/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
+++ b/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostingRepository extends JpaRepository<Posting, Long> {
@@ -32,6 +34,18 @@ public interface PostingRepository extends JpaRepository<Posting, Long> {
         @Param("endDate") LocalDate endDate,
         @Param("memberId") Long memberId,
         Pageable pageable
+    );
+
+    @Query("""
+            SELECT p FROM Posting p
+            WHERE p.memberId IN :memberIds
+              AND p.weekStartDate >= :startDate
+              AND p.weekStartDate <= :endDate
+            """)
+    List<Posting> findAllByMemberIdsAndDateRange(
+        @Param("memberIds") Collection<Long> memberIds,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
     );
 
     @Query("SELECT p FROM Posting p WHERE p.memberId = :memberId AND p.weekStartDate = :weekStartDate")

--- a/src/main/java/com/jk/amazon2/posting/service/PostingService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/PostingService.java
@@ -14,8 +14,8 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -29,28 +29,28 @@ public class PostingService {
     @Transactional(readOnly = true)
     public Page<PostingResponse.PostingDto> getPostings(
             LocalDate startDate, LocalDate endDate, Long memberId, Pageable pageable) {
-        // endDate가 null이면 startDate와 같게 설정 → startDate 단독 시 정확 일치 동작 유지
         LocalDate effectiveEndDate = (endDate != null) ? endDate : startDate;
 
-        Page<Posting> postings = postingRepository.findAllBySearchCondition(
-            startDate, effectiveEndDate, memberId, pageable
-        );
+        Page<Member> members = memberRepository.findActiveMembers(memberId, pageable);
 
-        Set<Long> memberIds = postings.getContent().stream()
-            .map(Posting::getMemberId)
-            .collect(Collectors.toSet());
+        List<Long> memberIds = members.getContent().stream()
+            .map(Member::getId)
+            .toList();
 
-        Map<Long, Member> memberMap = memberRepository.findAllById(memberIds).stream()
-            .collect(Collectors.toMap(Member::getId, m -> m));
+        if (memberIds.isEmpty()) {
+            return members.map(m -> PostingResponse.PostingDto.from(m, null, startDate));
+        }
 
-        return postings.map(p -> {
-            Member member = memberMap.get(p.getMemberId());
-            return PostingResponse.PostingDto.from(
-                p,
-                member != null ? member.getNickname() : null,
-                member != null ? member.getName() : null
-            );
-        });
+        Map<Long, Posting> postingMap = postingRepository
+            .findAllByMemberIdsAndDateRange(memberIds, startDate, effectiveEndDate)
+            .stream()
+            .collect(Collectors.toMap(Posting::getMemberId, p -> p));
+
+        return members.map(m -> PostingResponse.PostingDto.from(
+            m,
+            postingMap.get(m.getId()),
+            startDate
+        ));
     }
 
     @Transactional(isolation = Isolation.SERIALIZABLE)

--- a/src/test/java/com/jk/amazon2/posting/integration/PostingServiceIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/posting/integration/PostingServiceIntegrationTest.java
@@ -73,6 +73,34 @@ class PostingServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("[통합] 해당 주차 포스팅이 없는 멤버는 0으로 반환됨 [success]")
+    void getPostings_포스팅_없는_멤버_0으로_반환() {
+        // Given
+        memberRepository.save(Member.of("has-posting", "포스팅있음", "TECH"));
+        memberRepository.save(Member.of("no-posting", "포스팅없음", "TECH"));
+
+        LocalDate weekStart = LocalDate.of(2026, 6, 9);
+        Member withPosting = memberRepository.findByNickname("has-posting").orElseThrow();
+        postingRepository.save(new Posting(withPosting.getId(), weekStart, 3, 2, 1, 0, 0, 0, 0, "admin"));
+
+        // When
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(
+            weekStart, null, null, PageRequest.of(0, 10)
+        );
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        PostingResponse.PostingDto noPostDto = result.getContent().stream()
+            .filter(d -> "no-posting".equals(d.memberNickname()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(noPostDto.mon()).isZero();
+        assertThat(noPostDto.tue()).isZero();
+        assertThat(noPostDto.sun()).isZero();
+        assertThat(noPostDto.weekStartDate()).isEqualTo(weekStart);
+    }
+
+    @Test
     @DisplayName("[통합] 활성 멤버의 포스팅은 정상 조회됨 [success]")
     void getPostings_활성_멤버_포스팅_정상_조회() {
         // Given

--- a/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/PostingServiceTest.java
@@ -74,19 +74,19 @@ class PostingServiceTest {
     }
 
     @Test
-    @DisplayName("startDate만 전달하면 정확 일치 조회 (effectiveEndDate = startDate)")
-    void getPostings_startDate만_전달시_정확일치_조회() {
+    @DisplayName("포스팅이 있는 멤버는 실제 값으로 반환")
+    void getPostings_포스팅_있는_멤버_실제값_반환() {
         // Given
         LocalDate startDate = LocalDate.of(2026, 6, 9);
         Pageable pageable = PageRequest.of(0, 10);
-        Posting posting = new Posting(1L, startDate, 1, 2, 3, 4, 5, 6, 7, "admin");
-        Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
         Member member = Member.of("testUser", "test-name", "CAT01");
         ReflectionTestUtils.setField(member, "id", 1L);
+        Posting posting = new Posting(1L, startDate, 1, 2, 3, 4, 5, 6, 7, "admin");
+        Page<Member> memberPage = new PageImpl<>(List.of(member), pageable, 1);
 
-        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(null), eq(pageable)))
-            .thenReturn(postingPage);
-        when(memberRepository.findAllById(anyCollection())).thenReturn(List.of(member));
+        when(memberRepository.findActiveMembers(eq(null), eq(pageable))).thenReturn(memberPage);
+        when(postingRepository.findAllByMemberIdsAndDateRange(anyCollection(), eq(startDate), eq(startDate)))
+            .thenReturn(List.of(posting));
 
         // When
         Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, null, null, pageable);
@@ -97,32 +97,38 @@ class PostingServiceTest {
         assertThat(dto.weekStartDate()).isEqualTo(startDate);
         assertThat(dto.memberNickname()).isEqualTo("testUser");
         assertThat(dto.memberName()).isEqualTo("test-name");
-        verify(postingRepository).findAllBySearchCondition(startDate, startDate, null, pageable);
+        assertThat(dto.mon()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("startDate + endDate 전달 시 기간 범위 조회")
-    void getPostings_기간범위_조회() {
+    @DisplayName("포스팅이 없는 멤버는 0으로 반환")
+    void getPostings_포스팅_없는_멤버_0으로_반환() {
         // Given
-        LocalDate startDate = LocalDate.of(2026, 6, 2);
-        LocalDate endDate = LocalDate.of(2026, 6, 23);
+        LocalDate startDate = LocalDate.of(2026, 6, 9);
         Pageable pageable = PageRequest.of(0, 10);
-        Posting posting1 = new Posting(1L, LocalDate.of(2026, 6, 2), 1, 0, 0, 0, 0, 0, 0, "admin");
-        Posting posting2 = new Posting(1L, LocalDate.of(2026, 6, 9), 0, 1, 0, 0, 0, 0, 0, "admin");
-        Page<Posting> postingPage = new PageImpl<>(List.of(posting1, posting2), pageable, 2);
-        Member member = Member.of("testUser", "test-name", "CAT01");
+        Member member = Member.of("noPostUser", "무포스팅", "CAT01");
         ReflectionTestUtils.setField(member, "id", 1L);
+        Page<Member> memberPage = new PageImpl<>(List.of(member), pageable, 1);
 
-        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(endDate), eq(null), eq(pageable)))
-            .thenReturn(postingPage);
-        when(memberRepository.findAllById(anyCollection())).thenReturn(List.of(member));
+        when(memberRepository.findActiveMembers(eq(null), eq(pageable))).thenReturn(memberPage);
+        when(postingRepository.findAllByMemberIdsAndDateRange(anyCollection(), eq(startDate), eq(startDate)))
+            .thenReturn(List.of());
 
         // When
-        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, endDate, null, pageable);
+        Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, null, null, pageable);
 
         // Then
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        verify(postingRepository).findAllBySearchCondition(startDate, endDate, null, pageable);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        PostingResponse.PostingDto dto = result.getContent().get(0);
+        assertThat(dto.memberNickname()).isEqualTo("noPostUser");
+        assertThat(dto.weekStartDate()).isEqualTo(startDate);
+        assertThat(dto.mon()).isZero();
+        assertThat(dto.tue()).isZero();
+        assertThat(dto.wed()).isZero();
+        assertThat(dto.thu()).isZero();
+        assertThat(dto.fri()).isZero();
+        assertThat(dto.sat()).isZero();
+        assertThat(dto.sun()).isZero();
     }
 
     @Test
@@ -132,14 +138,14 @@ class PostingServiceTest {
         LocalDate startDate = LocalDate.of(2026, 6, 9);
         Long memberId = 2L;
         Pageable pageable = PageRequest.of(0, 10);
-        Posting posting = new Posting(memberId, startDate, 3, 3, 3, 3, 3, 3, 3, "admin");
-        Page<Posting> postingPage = new PageImpl<>(List.of(posting), pageable, 1);
         Member member = Member.of("targetUser", "test-name", "CAT01");
         ReflectionTestUtils.setField(member, "id", memberId);
+        Posting posting = new Posting(memberId, startDate, 3, 3, 3, 3, 3, 3, 3, "admin");
+        Page<Member> memberPage = new PageImpl<>(List.of(member), pageable, 1);
 
-        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(memberId), eq(pageable)))
-            .thenReturn(postingPage);
-        when(memberRepository.findAllById(anyCollection())).thenReturn(List.of(member));
+        when(memberRepository.findActiveMembers(eq(memberId), eq(pageable))).thenReturn(memberPage);
+        when(postingRepository.findAllByMemberIdsAndDateRange(anyCollection(), eq(startDate), eq(startDate)))
+            .thenReturn(List.of(posting));
 
         // When
         Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, null, memberId, pageable);
@@ -149,17 +155,15 @@ class PostingServiceTest {
         assertThat(result.getContent().get(0).memberId()).isEqualTo(memberId);
         assertThat(result.getContent().get(0).memberNickname()).isEqualTo("targetUser");
         assertThat(result.getContent().get(0).memberName()).isEqualTo("test-name");
-        verify(postingRepository).findAllBySearchCondition(startDate, startDate, memberId, pageable);
     }
 
     @Test
-    @DisplayName("조건 없으면 빈 페이지 반환")
-    void getPostings_데이터_없으면_빈_페이지_반환() {
+    @DisplayName("활성 멤버가 없으면 빈 페이지 반환")
+    void getPostings_활성멤버_없으면_빈_페이지_반환() {
         // Given
         LocalDate startDate = LocalDate.of(2026, 6, 9);
         Pageable pageable = PageRequest.of(0, 10);
-        when(postingRepository.findAllBySearchCondition(eq(startDate), eq(startDate), eq(null), eq(pageable)))
-            .thenReturn(Page.empty(pageable));
+        when(memberRepository.findActiveMembers(eq(null), eq(pageable))).thenReturn(Page.empty(pageable));
 
         // When
         Page<PostingResponse.PostingDto> result = postingService.getPostings(startDate, null, null, pageable);
@@ -167,5 +171,6 @@ class PostingServiceTest {
         // Then
         assertThat(result.isEmpty()).isTrue();
         assertThat(result.getTotalElements()).isZero();
+        verifyNoInteractions(postingRepository);
     }
 }


### PR DESCRIPTION
## 문제

`GET /postings`가 `Posting` 테이블 기준으로 쿼리하여 해당 주차에 포스팅이 없는 멤버는 응답에서 누락되는 문제가 있었습니다.

## 원인

```sql
-- 기존: Posting 기준 → 포스팅 레코드 없는 멤버 누락
SELECT p FROM Posting p WHERE EXISTS (SELECT m FROM Member m ...)
```

## 해결

쿼리 기준을 `Member` → `Posting` LEFT JOIN 방식(서비스 레이어 merge)으로 변경했습니다.

1. 활성 멤버 기준으로 페이징
2. 해당 멤버들의 포스팅을 별도 조회
3. 포스팅 없는 멤버 → `weekStartDate`와 함께 mon~sun 전부 `0` 반환

## 변경 사항

| 파일 | 변경 내용 |
|------|-----------|
| `MemberRepository` | `findActiveMembers()` 추가 |
| `PostingRepository` | `findAllByMemberIdsAndDateRange()` 추가, `findAllBySearchCondition()` 제거 |
| `PostingResponse.PostingDto` | `from(Member, Posting, LocalDate)`으로 재설계 — null Posting 시 0 반환 |
| `PostingService` | Member 기준 페이징으로 변경, empty IN 방지 처리 추가 |

## 응답 예시 (포스팅 없는 멤버)

```json
{
  "memberId": 2,
  "memberNickname": "user-b",
  "memberName": "홍길동",
  "weekStartDate": "2026-06-23",
  "mon": 0,
  "tue": 0,
  "wed": 0,
  "thu": 0,
  "fri": 0,
  "sat": 0,
  "sun": 0
}
```

## 체크리스트

- [x] 단위 테스트 작성 (포스팅 없는 멤버 0 반환 케이스 추가)
- [x] 통합 테스트 통과 (포스팅 없는 멤버 0 반환 통합 케이스 추가)
- [x] soft delete 멤버 제외 동작 유지 확인
- [x] empty memberIds 시 불필요한 쿼리 방지
- [ ] 코드 리뷰 요청
- [ ] 리그레션 확인

Closes #48