### PR TITLE
#50: 주간 통계 조회 API 추가

### DIFF
--- a/src/main/java/com/jk/amazon2/common/exception/ApiControllerAdvice.java
+++ b/src/main/java/com/jk/amazon2/common/exception/ApiControllerAdvice.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class ApiControllerAdvice {
@@ -21,5 +22,13 @@ public class ApiControllerAdvice {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiErrorResponse.of("INVALID_INPUT", errorMessage));
+    }
+
+    @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        String errorMessage = "잘못된 파라미터 형식입니다: " + ex.getName();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiErrorResponse.of("INVALID_PARAMETER_TYPE", errorMessage));
     }
 }

--- a/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
@@ -15,4 +15,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     @Query("SELECT m FROM Member m WHERE m.deleted = false AND (:memberId IS NULL OR m.id = :memberId)")
     Page<Member> findActiveMembers(@Param("memberId") Long memberId, Pageable pageable);
+
+    long countByDeletedFalse();
 }

--- a/src/main/java/com/jk/amazon2/posting/controller/MonitoringApiSpec.java
+++ b/src/main/java/com/jk/amazon2/posting/controller/MonitoringApiSpec.java
@@ -3,6 +3,7 @@ package com.jk.amazon2.posting.controller;
 import com.jk.amazon2.posting.dto.BatchStatusResponse;
 import com.jk.amazon2.posting.dto.ErrorLogDto;
 import com.jk.amazon2.posting.dto.StatisticsResponse;
+import com.jk.amazon2.posting.dto.WeeklyStatisticsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -48,5 +49,11 @@ public interface MonitoringApiSpec {
     ResponseEntity<StatisticsResponse> getStatistics(
             @Parameter(description = "시작일 (yyyy-MM-dd)") LocalDate startDate,
             @Parameter(description = "종료일 (yyyy-MM-dd)") LocalDate endDate
+    );
+
+    @Operation(summary = "주간 통계 조회", description = "특정 주의 총 포스팅 수, 총 인원, 활동 인원, 1인 평균 포스팅 수를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    ResponseEntity<WeeklyStatisticsResponse> getWeeklyStatistics(
+            @Parameter(description = "주 시작일 (yyyy-MM-dd, 월요일)") LocalDate weekStartDate
     );
 }

--- a/src/main/java/com/jk/amazon2/posting/controller/MonitoringController.java
+++ b/src/main/java/com/jk/amazon2/posting/controller/MonitoringController.java
@@ -3,6 +3,7 @@ package com.jk.amazon2.posting.controller;
 import com.jk.amazon2.posting.dto.BatchStatusResponse;
 import com.jk.amazon2.posting.dto.ErrorLogDto;
 import com.jk.amazon2.posting.dto.StatisticsResponse;
+import com.jk.amazon2.posting.dto.WeeklyStatisticsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -59,6 +60,14 @@ public class MonitoringController implements MonitoringApiSpec {
         @RequestParam LocalDate endDate
     ) {
         StatisticsResponse stats = statisticsService.getStatistics(startDate, endDate);
+        return ResponseEntity.ok(stats);
+    }
+
+    @GetMapping("/weekly-statistics")
+    public ResponseEntity<WeeklyStatisticsResponse> getWeeklyStatistics(
+        @RequestParam LocalDate weekStartDate
+    ) {
+        WeeklyStatisticsResponse stats = statisticsService.getWeeklyStatistics(weekStartDate);
         return ResponseEntity.ok(stats);
     }
 }

--- a/src/main/java/com/jk/amazon2/posting/dto/WeeklyStatisticsResponse.java
+++ b/src/main/java/com/jk/amazon2/posting/dto/WeeklyStatisticsResponse.java
@@ -1,0 +1,11 @@
+package com.jk.amazon2.posting.dto;
+
+import java.time.LocalDate;
+
+public record WeeklyStatisticsResponse(
+    LocalDate weekStartDate,
+    long totalPostingCount,
+    long totalMemberCount,
+    long activeMemberCount,
+    double averagePostingPerActiveMember
+) {}

--- a/src/main/java/com/jk/amazon2/posting/exception/PostingErrorCode.java
+++ b/src/main/java/com/jk/amazon2/posting/exception/PostingErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum PostingErrorCode implements ErrorCode {
     POSTING_NOT_FOUND(HttpStatus.NOT_FOUND, "포스팅을 찾을 수 없습니다"),
     POSTING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 포스팅입니다"),
-    POSTING_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "포스팅 저장에 실패했습니다");
+    POSTING_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "포스팅 저장에 실패했습니다"),
+    INVALID_WEEK_START_DATE(HttpStatus.BAD_REQUEST, "주간 시작일은 월요일이어야 합니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
+++ b/src/main/java/com/jk/amazon2/posting/repository/PostingRepository.java
@@ -54,4 +54,7 @@ public interface PostingRepository extends JpaRepository<Posting, Long> {
         @Param("memberId") Long memberId,
         @Param("weekStartDate") LocalDate weekStartDate
     );
+
+    @Query("SELECT p FROM Posting p WHERE p.weekStartDate = :weekStartDate")
+    List<Posting> findAllByWeekStartDate(@Param("weekStartDate") LocalDate weekStartDate);
 }

--- a/src/main/java/com/jk/amazon2/posting/service/StatisticsService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/StatisticsService.java
@@ -1,13 +1,18 @@
 package com.jk.amazon2.posting.service;
 
 import com.jk.amazon2.posting.dto.StatisticsResponse;
+import com.jk.amazon2.posting.dto.WeeklyStatisticsResponse;
 import com.jk.amazon2.posting.entity.Posting;
+import com.jk.amazon2.posting.exception.PostingErrorCode;
+import com.jk.amazon2.posting.exception.PostingException;
 import com.jk.amazon2.posting.repository.PostingRepository;
 import com.jk.amazon2.member.entity.Member;
 import com.jk.amazon2.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -67,8 +72,47 @@ public class StatisticsService {
         return new StatisticsResponse(startDate, endDate, totalPostings, userStats);
     }
 
+    @Transactional(readOnly = true)
+    public WeeklyStatisticsResponse getWeeklyStatistics(LocalDate weekStartDate) {
+        if (weekStartDate.getDayOfWeek() != DayOfWeek.MONDAY) {
+            throw new PostingException(PostingErrorCode.INVALID_WEEK_START_DATE);
+        }
+
+        long totalMemberCount = memberRepository.countByDeletedFalse();
+        List<Posting> weekPostings = postingRepository.findAllByWeekStartDate(weekStartDate);
+
+        long totalPostingCount = 0;
+        long activeMemberCount = 0;
+
+        for (Posting p : weekPostings) {
+            int memberTotal = nullToZero(p.getMon()) + nullToZero(p.getTue()) + nullToZero(p.getWed())
+                            + nullToZero(p.getThu()) + nullToZero(p.getFri())
+                            + nullToZero(p.getSat()) + nullToZero(p.getSun());
+            if (memberTotal > 0) {
+                activeMemberCount++;
+                totalPostingCount += memberTotal;
+            }
+        }
+
+        double average = activeMemberCount > 0
+            ? Math.round((double) totalPostingCount / activeMemberCount * 100.0) / 100.0
+            : 0.0;
+
+        return new WeeklyStatisticsResponse(
+            weekStartDate,
+            totalPostingCount,
+            totalMemberCount,
+            activeMemberCount,
+            average
+        );
+    }
+
     private boolean isInRange(LocalDate weekStart, LocalDate rangeStart, LocalDate rangeEnd) {
         LocalDate weekEnd = weekStart.plusDays(6);
         return !weekEnd.isBefore(rangeStart) && !weekStart.isAfter(rangeEnd);
+    }
+
+    private int nullToZero(Integer value) {
+        return value != null ? value : 0;
     }
 }

--- a/src/test/java/com/jk/amazon2/posting/service/StatisticsServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/StatisticsServiceTest.java
@@ -1,0 +1,147 @@
+package com.jk.amazon2.posting.service;
+
+import com.jk.amazon2.member.repository.MemberRepository;
+import com.jk.amazon2.posting.dto.WeeklyStatisticsResponse;
+import com.jk.amazon2.posting.entity.Posting;
+import com.jk.amazon2.posting.exception.PostingException;
+import com.jk.amazon2.posting.repository.PostingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticsServiceTest {
+
+    @Mock
+    private PostingRepository postingRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private StatisticsService statisticsService;
+
+    private Posting createPosting(Long memberId, LocalDate weekStart,
+                                  int mon, int tue, int wed, int thu, int fri, int sat, int sun) {
+        return new Posting(memberId, weekStart, mon, tue, wed, thu, fri, sat, sun, "test");
+    }
+
+    @Test
+    @DisplayName("주간 통계 - 활동 인원과 총 포스팅 수 집계")
+    void getWeeklyStatistics_활동인원_포스팅수_정상집계() {
+        // Given
+        LocalDate weekStart = LocalDate.of(2026, 6, 15); // 월요일
+        when(memberRepository.countByDeletedFalse()).thenReturn(10L);
+        when(postingRepository.findAllByWeekStartDate(weekStart)).thenReturn(List.of(
+            createPosting(1L, weekStart, 2, 1, 0, 0, 0, 0, 0),  // 3개
+            createPosting(2L, weekStart, 1, 1, 1, 0, 0, 0, 0),  // 3개
+            createPosting(3L, weekStart, 0, 0, 0, 0, 0, 0, 0)   // 0개 (비활동)
+        ));
+
+        // When
+        WeeklyStatisticsResponse result = statisticsService.getWeeklyStatistics(weekStart);
+
+        // Then
+        assertThat(result.weekStartDate()).isEqualTo(weekStart);
+        assertThat(result.totalMemberCount()).isEqualTo(10L);
+        assertThat(result.activeMemberCount()).isEqualTo(2L);
+        assertThat(result.totalPostingCount()).isEqualTo(6L);
+        assertThat(result.averagePostingPerActiveMember()).isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("주간 통계 - 해당 주 포스팅이 없으면 평균은 0.0")
+    void getWeeklyStatistics_포스팅없으면_평균0() {
+        // Given
+        LocalDate weekStart = LocalDate.of(2026, 6, 15);
+        when(memberRepository.countByDeletedFalse()).thenReturn(5L);
+        when(postingRepository.findAllByWeekStartDate(weekStart)).thenReturn(List.of());
+
+        // When
+        WeeklyStatisticsResponse result = statisticsService.getWeeklyStatistics(weekStart);
+
+        // Then
+        assertThat(result.totalPostingCount()).isEqualTo(0L);
+        assertThat(result.activeMemberCount()).isEqualTo(0L);
+        assertThat(result.averagePostingPerActiveMember()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("주간 통계 - 1인 평균 포스팅 수 소수점 2자리 반올림")
+    void getWeeklyStatistics_평균_소수점2자리() {
+        // Given
+        LocalDate weekStart = LocalDate.of(2026, 6, 15);
+        when(memberRepository.countByDeletedFalse()).thenReturn(10L);
+        when(postingRepository.findAllByWeekStartDate(weekStart)).thenReturn(List.of(
+            createPosting(1L, weekStart, 1, 0, 0, 0, 0, 0, 0),
+            createPosting(2L, weekStart, 1, 0, 0, 0, 0, 0, 0),
+            createPosting(3L, weekStart, 1, 0, 0, 0, 0, 0, 0)
+        ));
+
+        // When
+        WeeklyStatisticsResponse result = statisticsService.getWeeklyStatistics(weekStart);
+
+        // Then: 3 / 3 = 1.0
+        assertThat(result.totalPostingCount()).isEqualTo(3L);
+        assertThat(result.activeMemberCount()).isEqualTo(3L);
+        assertThat(result.averagePostingPerActiveMember()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("주간 통계 - null 포스팅 값은 0으로 처리")
+    void getWeeklyStatistics_null값_0으로처리() {
+        // Given
+        LocalDate weekStart = LocalDate.of(2026, 6, 15);
+        when(memberRepository.countByDeletedFalse()).thenReturn(3L);
+
+        Posting postingWithNulls = new Posting(1L, weekStart, null, null, null, null, null, null, null, "test");
+        when(postingRepository.findAllByWeekStartDate(weekStart)).thenReturn(List.of(postingWithNulls));
+
+        // When
+        WeeklyStatisticsResponse result = statisticsService.getWeeklyStatistics(weekStart);
+
+        // Then: null 포스팅은 비활동 처리
+        assertThat(result.activeMemberCount()).isEqualTo(0L);
+        assertThat(result.totalPostingCount()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("주간 통계 - totalMemberCount는 삭제되지 않은 전체 회원 수")
+    void getWeeklyStatistics_총인원은_비삭제회원수() {
+        // Given
+        LocalDate weekStart = LocalDate.of(2026, 6, 15);
+        when(memberRepository.countByDeletedFalse()).thenReturn(7L);
+        when(postingRepository.findAllByWeekStartDate(weekStart)).thenReturn(List.of(
+            createPosting(1L, weekStart, 1, 0, 0, 0, 0, 0, 0)
+        ));
+
+        // When
+        WeeklyStatisticsResponse result = statisticsService.getWeeklyStatistics(weekStart);
+
+        // Then
+        assertThat(result.totalMemberCount()).isEqualTo(7L);
+        assertThat(result.activeMemberCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("주간 통계 - 월요일이 아닌 날짜 입력 시 예외 발생")
+    void getWeeklyStatistics_월요일아닌날짜_예외발생() {
+        // Given
+        LocalDate tuesday = LocalDate.of(2026, 6, 16); // 화요일
+
+        // When & Then
+        assertThatThrownBy(() -> statisticsService.getWeeklyStatistics(tuesday))
+            .isInstanceOf(PostingException.class)
+            .hasMessage("주간 시작일은 월요일이어야 합니다");
+    }
+}


### PR DESCRIPTION
## 개요
해당 주의 총 포스팅 수, 총 인원, 활동 인원, 1인 평균 포스팅 수를 반환하는 주간 통계 조회 API를 추가합니다.

## 변경사항

- `WeeklyStatisticsResponse.java`: 주간 통계 응답 DTO 추가
- `StatisticsService.java`: `getWeeklyStatistics()` 구현 (`@Transactional(readOnly = true)`, 월요일 검증)
- `MonitoringController.java`: `GET /api/postings/weekly-statistics` 엔드포인트 추가
- `MonitoringApiSpec.java`: Swagger 스펙 추가
- `PostingRepository.java`: `findAllByWeekStartDate(LocalDate)` 오버로드 추가
- `MemberRepository.java`: `countByDeletedFalse()` 추가
- `PostingErrorCode.java`: `INVALID_WEEK_START_DATE` (400) 추가
- `ApiControllerAdvice.java`: `MethodArgumentTypeMismatchException` 핸들러 추가
- `StatisticsServiceTest.java`: BDD + AssertJ 단위 테스트 6개

## 테스트 방법

```bash
# 정상 요청 (월요일)
GET /api/postings/weekly-statistics?weekStartDate=2026-06-16

# 예외 케이스
GET /api/postings/weekly-statistics?weekStartDate=2026-06-17  # 화요일 → 400
GET /api/postings/weekly-statistics?weekStartDate=abc         # 형식 오류 → 400
```

예상 응답:
```json
{
  "weekStartDate": "2026-06-16",
  "totalPostingCount": 15,
  "totalMemberCount": 10,
  "activeMemberCount": 7,
  "averagePostingPerActiveMember": 2.14
}
```

## 체크리스트

- [x] 단위 테스트 작성/수정 완료
- [x] CI 테스트 통과
- [x] 코드 리뷰 요청 완료
- [x] 기존 기능 리그레션 확인

## 관련 이슈

Closes #50