### PR TITLE
#52: soft delete된 멤버 복구 API 추가 (PATCH /members/{nickname}/restore)

### DIFF
--- a/src/main/java/com/jk/amazon2/member/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/member/controller/MemberController.java
@@ -92,4 +92,15 @@ public class MemberController implements MemberApiSpec {
                 .status(HttpStatus.NO_CONTENT)
                 .build();
     }
+
+    @Override
+    @PatchMapping("/members/{nickname}/restore")
+    public ResponseEntity<Void> restoreMember(
+            @PathVariable String nickname
+    ) {
+        memberService.restore(nickname);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
 }

--- a/src/main/java/com/jk/amazon2/member/controller/spec/MemberApiSpec.java
+++ b/src/main/java/com/jk/amazon2/member/controller/spec/MemberApiSpec.java
@@ -33,4 +33,10 @@ public interface MemberApiSpec {
     @Operation(summary = "유저 영구 삭제")
     @ApiResponse(responseCode = "204", description = "유저 영구 삭제 성공")
     ResponseEntity<Void> hardDeleteMember(String nickname);
+
+    @Operation(summary = "soft delete된 유저 복구")
+    @ApiResponse(responseCode = "204", description = "유저 복구 성공")
+    @ApiResponse(responseCode = "400", description = "이미 활성 상태인 회원")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원")
+    ResponseEntity<Void> restoreMember(String nickname);
 }

--- a/src/main/java/com/jk/amazon2/member/entity/Member.java
+++ b/src/main/java/com/jk/amazon2/member/entity/Member.java
@@ -46,4 +46,8 @@ public class Member extends BaseAudit {
     public void softDelete() {
         this.deleted = true;
     }
+
+    public void restore() {
+        this.deleted = false;
+    }
 }

--- a/src/main/java/com/jk/amazon2/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/jk/amazon2/member/exception/MemberErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode{
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     MEMBER_NOT_DELETED(HttpStatus.BAD_REQUEST, "소프트 삭제된 회원만 영구 삭제가 가능합니다."),
+    MEMBER_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "이미 활성 상태인 회원입니다."),
     MEMBER_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "닉네임은 필수 입니다."),
     MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다."),
     MEMBER_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 닉네임 입니다."),

--- a/src/main/java/com/jk/amazon2/member/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/member/service/MemberService.java
@@ -71,6 +71,16 @@ public class MemberService {
     }
 
     @Transactional
+    public void restore(String nickname) {
+        Member member = memberRepository.findByNickname(nickname)
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+        if (!member.isDeleted()) {
+            throw new RestApiException(MemberErrorCode.MEMBER_ALREADY_ACTIVE);
+        }
+        member.restore();
+    }
+
+    @Transactional
     public void hardDelete(String nickname) {
         Member member = memberRepository.findByNickname(nickname)
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
@@ -169,6 +169,52 @@ class MemberControllerTest {
     }
 
     @Nested
+    @DisplayName("Member 복구 - 단위 테스트")
+    class RestoreMember {
+        @Test
+        @DisplayName("회원 복구 성공 [success]")
+        void restoreMember_success() {
+            // Given
+            String nickname = "test_member";
+
+            // When
+            ResponseEntity<Void> response = memberController.restoreMember(nickname);
+
+            // Then
+            assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.NO_CONTENT);
+            verify(memberService).restore(nickname);
+        }
+
+        @Test
+        @DisplayName("회원 복구 실패 - 존재하지 않는 닉네임 [fail]")
+        void restoreMember_fail_not_found() {
+            // Given
+            String nickname = "non_existent";
+            doThrow(new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND))
+                    .when(memberService).restore(nickname);
+
+            // When & Then
+            assertThatThrownBy(() -> memberController.restoreMember(nickname))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("회원 복구 실패 - 이미 활성 상태인 회원 [fail]")
+        void restoreMember_fail_already_active() {
+            // Given
+            String nickname = "active_member";
+            doThrow(new RestApiException(MemberErrorCode.MEMBER_ALREADY_ACTIVE))
+                    .when(memberService).restore(nickname);
+
+            // When & Then
+            assertThatThrownBy(() -> memberController.restoreMember(nickname))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_ALREADY_ACTIVE.getMessage());
+        }
+    }
+
+    @Nested
     @DisplayName("Member 영구 삭제 - 단위 테스트")
     class HardDeleteMember {
         @Test

--- a/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
@@ -272,6 +272,79 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
     }
 
     @Nested
+    @DisplayName("Member 복구 통합 테스트")
+    class RestoreMember {
+        private String categoryCode = "DEV";
+
+        @BeforeEach
+        void setUp() {
+            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
+            try {
+                jdbcTemplate.update(insertCategorySql, categoryCode, "개발", "개발팀");
+            } catch (Exception e) {
+                // 이미 존재하면 무시
+            }
+        }
+
+        @DisplayName("[통합] PATCH /members/{nickname}/restore - soft delete된 회원 복구 성공 [204 No Content]")
+        @Test
+        void restoreMember_Integration_Success() {
+            // Given
+            String nickname = "restore_user";
+            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, true, NOW(), 'system', NOW(), 'system')";
+            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+
+            // When & Then (API 검증)
+            RestAssuredMockMvc
+                    .given()
+                    .when()
+                    .patch("/members/{nickname}/restore", nickname)
+                    .then()
+                    .statusCode(HttpStatus.NO_CONTENT.value());
+
+            // DB 검증 - deleted = false
+            em.flush();
+            String selectSql = "SELECT deleted FROM member WHERE nickname = ?";
+            Boolean deleted = jdbcTemplate.queryForObject(selectSql, Boolean.class, nickname);
+            assertThat(deleted).isFalse();
+        }
+
+        @DisplayName("[통합] PATCH /members/{nickname}/restore - 존재하지 않는 회원 복구 실패 [404 Not Found]")
+        @Test
+        void restoreMember_Integration_Fail_NotFound() {
+            // Given
+            String nickname = "non_existent_restore_user";
+
+            // When & Then
+            RestAssuredMockMvc
+                    .given()
+                    .when()
+                    .patch("/members/{nickname}/restore", nickname)
+                    .then()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_NOT_FOUND.name()));
+        }
+
+        @DisplayName("[통합] PATCH /members/{nickname}/restore - 이미 활성 상태인 회원 복구 실패 [400 Bad Request]")
+        @Test
+        void restoreMember_Integration_Fail_AlreadyActive() {
+            // Given
+            String nickname = "already_active_user";
+            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
+            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+
+            // When & Then
+            RestAssuredMockMvc
+                    .given()
+                    .when()
+                    .patch("/members/{nickname}/restore", nickname)
+                    .then()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .body("code", equalTo(MemberErrorCode.MEMBER_ALREADY_ACTIVE.name()));
+        }
+    }
+
+    @Nested
     @DisplayName("Member 삭제 통합 테스트")
     class DeleteMember {
         private String categoryCode = "DEV";

--- a/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
@@ -286,6 +286,56 @@ class MemberServiceTest {
     }
 
     @Nested
+    @DisplayName("Member 복구 - 단위 테스트")
+    class RestoreMember {
+        @Test
+        @DisplayName("soft delete된 회원 복구 성공 [success]")
+        void restore_success() {
+            // Given
+            String nickname = "test_member";
+            Member member = Member.of(nickname, "test-name", "DEV");
+            member.softDelete();
+            given(memberRepository.findByNickname(nickname))
+                    .willReturn(Optional.of(member));
+
+            // When
+            memberService.restore(nickname);
+
+            // Then
+            assertThat(member.isDeleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("회원 복구 실패 - 존재하지 않는 닉네임 [fail]")
+        void restore_fail_not_found() {
+            // Given
+            String nickname = "non_existent";
+            given(memberRepository.findByNickname(nickname))
+                    .willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> memberService.restore(nickname))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("회원 복구 실패 - 이미 활성 상태인 회원 [fail]")
+        void restore_fail_already_active() {
+            // Given
+            String nickname = "test_member";
+            Member member = Member.of(nickname, "test-name", "DEV");
+            given(memberRepository.findByNickname(nickname))
+                    .willReturn(Optional.of(member));
+
+            // When & Then
+            assertThatThrownBy(() -> memberService.restore(nickname))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(MemberErrorCode.MEMBER_ALREADY_ACTIVE.getMessage());
+        }
+    }
+
+    @Nested
     @DisplayName("Member 영구 삭제 - 단위 테스트")
     class HardDeleteMember {
         @Test


### PR DESCRIPTION
## Summary

- soft delete(`deleted=true`) 처리된 멤버를 `PATCH /members/{nickname}/restore`로 복구 (`deleted=false`)
- 이미 활성 상태인 멤버 복구 시도 시 400 반환 (`MEMBER_ALREADY_ACTIVE`)
- Service / Controller / Integration 3계층 테스트 완비

## Test plan

- [x] `MemberServiceTest` — restore 성공 / NOT_FOUND / ALREADY_ACTIVE 단위 테스트
- [x] `MemberControllerTest` — restore 성공(204) / NOT_FOUND / ALREADY_ACTIVE 단위 테스트
- [x] `MemberIntegrationTest` — 복구 후 DB `deleted=false` 검증 / NOT_FOUND(404) / ALREADY_ACTIVE(400) 통합 테스트
- [x] 코드 리뷰 완료 (PASS)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)