### PR TITLE
#29: StatisticsService 통계 쿼리 최적화 (findAll → 날짜 범위 쿼리)

### DIFF
--- a/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
+++ b/src/main/java/com/jk/amazon2/member/repository/MemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
@@ -17,4 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     Page<Member> findActiveMembers(@Param("memberId") Long memberId, Pageable pageable);
 
     long countByDeletedFalse();
+
+    List<Member> findAllByDeletedFalse();
 }

--- a/src/main/java/com/jk/amazon2/posting/service/StatisticsService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/StatisticsService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,11 +27,15 @@ public class StatisticsService {
     @Transactional(readOnly = true)
     public StatisticsResponse getStatistics(LocalDate startDate, LocalDate endDate) {
         List<Member> members = memberRepository.findAllByDeletedFalse();
+        if (members.isEmpty()) {
+            return new StatisticsResponse(startDate, endDate, 0, List.of());
+        }
+
         List<Long> memberIds = members.stream().map(Member::getId).toList();
         List<Posting> postings = postingRepository.findAllByMemberIdsAndDateRange(memberIds, startDate, endDate);
 
         Map<Long, List<Posting>> postingsByMember = postings.stream()
-            .collect(java.util.stream.Collectors.groupingBy(Posting::getMemberId));
+            .collect(Collectors.groupingBy(Posting::getMemberId));
 
         int totalPostings = 0;
         List<StatisticsResponse.UserStatistics> userStats = new ArrayList<>();
@@ -49,16 +54,17 @@ public class StatisticsService {
             dayOfWeekCounts.put("sun", 0);
 
             for (Posting p : memberPostings) {
-                memberTotal += p.getMon() + p.getTue() + p.getWed() + p.getThu() +
-                             p.getFri() + p.getSat() + p.getSun();
+                memberTotal += nullToZero(p.getMon()) + nullToZero(p.getTue()) + nullToZero(p.getWed())
+                             + nullToZero(p.getThu()) + nullToZero(p.getFri())
+                             + nullToZero(p.getSat()) + nullToZero(p.getSun());
 
-                dayOfWeekCounts.put("mon", dayOfWeekCounts.get("mon") + p.getMon());
-                dayOfWeekCounts.put("tue", dayOfWeekCounts.get("tue") + p.getTue());
-                dayOfWeekCounts.put("wed", dayOfWeekCounts.get("wed") + p.getWed());
-                dayOfWeekCounts.put("thu", dayOfWeekCounts.get("thu") + p.getThu());
-                dayOfWeekCounts.put("fri", dayOfWeekCounts.get("fri") + p.getFri());
-                dayOfWeekCounts.put("sat", dayOfWeekCounts.get("sat") + p.getSat());
-                dayOfWeekCounts.put("sun", dayOfWeekCounts.get("sun") + p.getSun());
+                dayOfWeekCounts.put("mon", dayOfWeekCounts.get("mon") + nullToZero(p.getMon()));
+                dayOfWeekCounts.put("tue", dayOfWeekCounts.get("tue") + nullToZero(p.getTue()));
+                dayOfWeekCounts.put("wed", dayOfWeekCounts.get("wed") + nullToZero(p.getWed()));
+                dayOfWeekCounts.put("thu", dayOfWeekCounts.get("thu") + nullToZero(p.getThu()));
+                dayOfWeekCounts.put("fri", dayOfWeekCounts.get("fri") + nullToZero(p.getFri()));
+                dayOfWeekCounts.put("sat", dayOfWeekCounts.get("sat") + nullToZero(p.getSat()));
+                dayOfWeekCounts.put("sun", dayOfWeekCounts.get("sun") + nullToZero(p.getSun()));
             }
 
             if (memberTotal > 0) {

--- a/src/main/java/com/jk/amazon2/posting/service/StatisticsService.java
+++ b/src/main/java/com/jk/amazon2/posting/service/StatisticsService.java
@@ -23,14 +23,21 @@ public class StatisticsService {
     private final PostingRepository postingRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional(readOnly = true)
     public StatisticsResponse getStatistics(LocalDate startDate, LocalDate endDate) {
-        List<Member> members = memberRepository.findAll();
-        List<Posting> postings = postingRepository.findAll();
+        List<Member> members = memberRepository.findAllByDeletedFalse();
+        List<Long> memberIds = members.stream().map(Member::getId).toList();
+        List<Posting> postings = postingRepository.findAllByMemberIdsAndDateRange(memberIds, startDate, endDate);
+
+        Map<Long, List<Posting>> postingsByMember = postings.stream()
+            .collect(java.util.stream.Collectors.groupingBy(Posting::getMemberId));
 
         int totalPostings = 0;
         List<StatisticsResponse.UserStatistics> userStats = new ArrayList<>();
 
         for (Member member : members) {
+            List<Posting> memberPostings = postingsByMember.getOrDefault(member.getId(), List.of());
+
             int memberTotal = 0;
             Map<String, Integer> dayOfWeekCounts = new HashMap<>();
             dayOfWeekCounts.put("mon", 0);
@@ -41,21 +48,17 @@ public class StatisticsService {
             dayOfWeekCounts.put("sat", 0);
             dayOfWeekCounts.put("sun", 0);
 
-            for (Posting p : postings) {
-                if (p.getMemberId().equals(member.getId()) &&
-                    isInRange(p.getWeekStartDate(), startDate, endDate)) {
+            for (Posting p : memberPostings) {
+                memberTotal += p.getMon() + p.getTue() + p.getWed() + p.getThu() +
+                             p.getFri() + p.getSat() + p.getSun();
 
-                    memberTotal += p.getMon() + p.getTue() + p.getWed() + p.getThu() +
-                                 p.getFri() + p.getSat() + p.getSun();
-
-                    dayOfWeekCounts.put("mon", dayOfWeekCounts.get("mon") + p.getMon());
-                    dayOfWeekCounts.put("tue", dayOfWeekCounts.get("tue") + p.getTue());
-                    dayOfWeekCounts.put("wed", dayOfWeekCounts.get("wed") + p.getWed());
-                    dayOfWeekCounts.put("thu", dayOfWeekCounts.get("thu") + p.getThu());
-                    dayOfWeekCounts.put("fri", dayOfWeekCounts.get("fri") + p.getFri());
-                    dayOfWeekCounts.put("sat", dayOfWeekCounts.get("sat") + p.getSat());
-                    dayOfWeekCounts.put("sun", dayOfWeekCounts.get("sun") + p.getSun());
-                }
+                dayOfWeekCounts.put("mon", dayOfWeekCounts.get("mon") + p.getMon());
+                dayOfWeekCounts.put("tue", dayOfWeekCounts.get("tue") + p.getTue());
+                dayOfWeekCounts.put("wed", dayOfWeekCounts.get("wed") + p.getWed());
+                dayOfWeekCounts.put("thu", dayOfWeekCounts.get("thu") + p.getThu());
+                dayOfWeekCounts.put("fri", dayOfWeekCounts.get("fri") + p.getFri());
+                dayOfWeekCounts.put("sat", dayOfWeekCounts.get("sat") + p.getSat());
+                dayOfWeekCounts.put("sun", dayOfWeekCounts.get("sun") + p.getSun());
             }
 
             if (memberTotal > 0) {
@@ -105,11 +108,6 @@ public class StatisticsService {
             activeMemberCount,
             average
         );
-    }
-
-    private boolean isInRange(LocalDate weekStart, LocalDate rangeStart, LocalDate rangeEnd) {
-        LocalDate weekEnd = weekStart.plusDays(6);
-        return !weekEnd.isBefore(rangeStart) && !weekStart.isAfter(rangeEnd);
     }
 
     private int nullToZero(Integer value) {

--- a/src/test/java/com/jk/amazon2/posting/service/StatisticsServiceTest.java
+++ b/src/test/java/com/jk/amazon2/posting/service/StatisticsServiceTest.java
@@ -1,6 +1,8 @@
 package com.jk.amazon2.posting.service;
 
+import com.jk.amazon2.member.entity.Member;
 import com.jk.amazon2.member.repository.MemberRepository;
+import com.jk.amazon2.posting.dto.StatisticsResponse;
 import com.jk.amazon2.posting.dto.WeeklyStatisticsResponse;
 import com.jk.amazon2.posting.entity.Posting;
 import com.jk.amazon2.posting.exception.PostingException;
@@ -11,12 +13,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +40,132 @@ class StatisticsServiceTest {
     private Posting createPosting(Long memberId, LocalDate weekStart,
                                   int mon, int tue, int wed, int thu, int fri, int sat, int sun) {
         return new Posting(memberId, weekStart, mon, tue, wed, thu, fri, sat, sun, "test");
+    }
+
+    private Member createMember(Long id, String nickname) {
+        Member member = Member.of(nickname, nickname, null);
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    // ==================== getStatistics ====================
+
+    @Test
+    @DisplayName("기간 통계 - 멤버별 포스팅 수와 요일별 집계 정상 동작")
+    void getStatistics_멤버별_집계_정상동작() {
+        // Given
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 30);
+
+        Member memberA = createMember(1L, "alice");
+        Member memberB = createMember(2L, "bob");
+
+        LocalDate weekStart = LocalDate.of(2026, 6, 2);
+        when(memberRepository.findAllByDeletedFalse()).thenReturn(List.of(memberA, memberB));
+        when(postingRepository.findAllByMemberIdsAndDateRange(List.of(1L, 2L), start, end)).thenReturn(List.of(
+            createPosting(1L, weekStart, 3, 2, 1, 0, 0, 0, 0),  // alice: 6개
+            createPosting(2L, weekStart, 1, 1, 0, 0, 0, 0, 0)   // bob: 2개
+        ));
+
+        // When
+        StatisticsResponse result = statisticsService.getStatistics(start, end);
+
+        // Then
+        assertThat(result.totalPostings()).isEqualTo(8);
+        assertThat(result.users()).hasSize(2);
+
+        StatisticsResponse.UserStatistics aliceStats = result.users().stream()
+            .filter(u -> u.nickname().equals("alice")).findFirst().orElseThrow();
+        assertThat(aliceStats.totalPostings()).isEqualTo(6);
+        assertThat(aliceStats.byDayOfWeek().get("mon")).isEqualTo(3);
+        assertThat(aliceStats.byDayOfWeek().get("tue")).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("기간 통계 - 포스팅 없는 멤버는 결과에서 제외")
+    void getStatistics_포스팅없는_멤버_제외() {
+        // Given
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 30);
+
+        Member memberA = createMember(1L, "alice");
+        Member memberB = createMember(2L, "bob");
+
+        when(memberRepository.findAllByDeletedFalse()).thenReturn(List.of(memberA, memberB));
+        when(postingRepository.findAllByMemberIdsAndDateRange(any(), eq(start), eq(end))).thenReturn(List.of(
+            createPosting(1L, LocalDate.of(2026, 6, 2), 1, 0, 0, 0, 0, 0, 0)
+        ));
+
+        // When
+        StatisticsResponse result = statisticsService.getStatistics(start, end);
+
+        // Then: bob은 포스팅이 없으므로 제외
+        assertThat(result.users()).hasSize(1);
+        assertThat(result.users().get(0).nickname()).isEqualTo("alice");
+    }
+
+    @Test
+    @DisplayName("기간 통계 - null 요일 값은 0으로 처리 (NPE 방어)")
+    void getStatistics_null요일값_0으로처리() {
+        // Given
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 30);
+
+        Member member = createMember(1L, "alice");
+        Posting postingWithNulls = new Posting(1L, LocalDate.of(2026, 6, 2), null, null, 2, null, null, null, null, "test");
+
+        when(memberRepository.findAllByDeletedFalse()).thenReturn(List.of(member));
+        when(postingRepository.findAllByMemberIdsAndDateRange(any(), eq(start), eq(end)))
+            .thenReturn(List.of(postingWithNulls));
+
+        // When: NPE 발생하지 않아야 함
+        StatisticsResponse result = statisticsService.getStatistics(start, end);
+
+        // Then
+        assertThat(result.users()).hasSize(1);
+        assertThat(result.users().get(0).totalPostings()).isEqualTo(2);
+        assertThat(result.users().get(0).byDayOfWeek().get("wed")).isEqualTo(2);
+        assertThat(result.users().get(0).byDayOfWeek().get("mon")).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("기간 통계 - 활성 멤버가 없으면 빈 결과 반환")
+    void getStatistics_활성멤버없으면_빈결과() {
+        // Given
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 30);
+
+        when(memberRepository.findAllByDeletedFalse()).thenReturn(List.of());
+
+        // When
+        StatisticsResponse result = statisticsService.getStatistics(start, end);
+
+        // Then: DB 쿼리 없이 즉시 반환
+        assertThat(result.totalPostings()).isEqualTo(0);
+        assertThat(result.users()).isEmpty();
+        verify(postingRepository, org.mockito.Mockito.never())
+            .findAllByMemberIdsAndDateRange(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("기간 통계 - DB에 올바른 memberIds와 날짜 범위로 쿼리")
+    void getStatistics_올바른_파라미터로_쿼리() {
+        // Given
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 30);
+
+        Member memberA = createMember(10L, "alice");
+        Member memberB = createMember(20L, "bob");
+
+        when(memberRepository.findAllByDeletedFalse()).thenReturn(List.of(memberA, memberB));
+        when(postingRepository.findAllByMemberIdsAndDateRange(any(), eq(start), eq(end)))
+            .thenReturn(List.of());
+
+        // When
+        statisticsService.getStatistics(start, end);
+
+        // Then
+        verify(postingRepository).findAllByMemberIdsAndDateRange(List.of(10L, 20L), start, end);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `getStatistics()`의 `findAll()` × 2 → `findAllByDeletedFalse()` + `findAllByMemberIdsAndDateRange()`로 교체해 OOM 위험 제거
- DB에서 날짜 범위 필터링, 애플리케이션에서 멤버별 집계 (`groupingBy` + Map 매핑)
- nullable `Integer` 요일 필드에 `nullToZero()` 적용 및 빈 멤버 early-return 추가
- `getStatistics` 단위 테스트 5개 추가 (멤버별 집계, 미활동 멤버 제외, null 방어, early-return, 쿼리 파라미터 검증)

## Changes

- `MemberRepository`: `findAllByDeletedFalse()` 추가
- `StatisticsService`: 쿼리 최적화, null 방어, `@Transactional(readOnly = true)` 추가
- `StatisticsServiceTest`: `getStatistics` 테스트 5개 추가

## Test plan

- [x] `StatisticsServiceTest` 전체 통과 확인
- [x] 전체 테스트 스위트 (`./gradlew test`) 통과 확인
- [x] 코드 리뷰 완료 (Notion: 2026-06-24 #29 코드 리뷰)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)