### PR TITLE
#42: IntegrationTestSupport @Transactional 제거 및 테스트 격리 개선

### DIFF
--- a/src/test/java/com/jk/amazon2/category/integration/CategoryIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/category/integration/CategoryIntegrationTest.java
@@ -1,11 +1,10 @@
 package com.jk.amazon2.category.integration;
 
-import com.jk.amazon2.category.dto.CategoryRequest;
 import com.jk.amazon2.category.exception.CategoryErrorCode;
+import com.jk.amazon2.testsupport.CategoryMother;
 import com.jk.amazon2.testsupport.IntegrationTestSupport;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
-import jakarta.persistence.EntityManager;
 import net.datafaker.Faker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,8 +30,6 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
     private MockMvc mockMvc;
     @Autowired
     private JdbcTemplate jdbcTemplate;
-    @Autowired
-    private EntityManager entityManager;
 
     private final Faker faker = new Faker(Locale.of("ko"));
 
@@ -49,13 +46,11 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
         String name = faker.company().industry();
         String description = faker.lorem().sentence();
 
-        var requestDto = new CategoryRequest.CategoryCreateDto(code, name, description);
-
         // when & then (API 검증)
         RestAssuredMockMvc
                 .given()
                 .contentType(ContentType.JSON)
-                .body(requestDto)
+                .body(CategoryMother.createDto(code, name, description))
                 .when()
                 .post("/categories")
                 .then()
@@ -63,11 +58,10 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
                 .body("categoryCode", equalTo(code))
                 .body("categoryName", equalTo(name))
                 .body("description", equalTo(description));
-        entityManager.flush();
 
         // then (DB에 저장되었는지 검증)
-        var sql = "SELECT name FROM blog_category WHERE code = ?";
-        String savedName = jdbcTemplate.queryForObject(sql, String.class, code);
+        String savedName = jdbcTemplate.queryForObject(
+                "SELECT name FROM blog_category WHERE code = ?", String.class, code);
         assertThat(savedName).isEqualTo(name);
     }
 
@@ -79,18 +73,13 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
         String name = faker.company().industry();
         String description = faker.lorem().sentence();
 
-        String initSql = """
-                    INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES(?, ?, ?, NOW(), "system")
-                """;
-        jdbcTemplate.update(initSql, code, name,description);
-
-        var requestSameCodeDto = new CategoryRequest.CategoryCreateDto(code, name, description);
+        jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.fullParams(code, name, description));
 
         // when & then
         RestAssuredMockMvc
                 .given()
                 .contentType(ContentType.JSON)
-                .body(requestSameCodeDto)
+                .body(CategoryMother.createDto(code, name, description))
                 .when()
                 .post("/categories")
                 .then()
@@ -99,35 +88,31 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
                 .body("message", equalTo(CategoryErrorCode.CATEGORY_ALREADY_EXISTS.getMessage()));
 
         // then - DB에 하나만 존재하는지 확인
-        var testSql = "SELECT count(*) FROM blog_category";
-        Integer count = jdbcTemplate.queryForObject(testSql, Integer.class);
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM blog_category", Integer.class);
         assertThat(count).isEqualTo(1);
     }
 
     @Nested
     @DisplayName("Category 수정 통합 테스트")
-    class UpdateCategory{
+    class UpdateCategory {
 
         @DisplayName("[통합] PUT /categories/{code} - 수정 성공 및 DB 반영 확인 [200 OK]")
         @Test
         void updateCategory_Integration_Success() {
             // given
             String code = "TECH";
-            String originalName = "Original Name";
-            String originalDesc = "Original Description";
-            String insertSql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            jdbcTemplate.update(insertSql, code, originalName, originalDesc);
+            jdbcTemplate.update(CategoryMother.INSERT_SQL,
+                    CategoryMother.fullParams(code, "Original Name", "Original Description"));
 
-            // 2. 수정할 데이터 준비
             String updateName = "Updated Name";
             String updateDesc = "Updated Description";
-            var requestDto = CategoryRequest.CategoryUpdateDto.of(updateName, updateDesc);
 
             // when & then (API 호출 및 응답 검증)
             RestAssuredMockMvc
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(requestDto)
+                    .body(CategoryMother.updateDto(updateName, updateDesc))
                     .when()
                     .put("/categories/{code}", code)
                     .then()
@@ -135,12 +120,10 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
                     .body("categoryCode", equalTo(code))
                     .body("categoryName", equalTo(updateName))
                     .body("description", equalTo(updateDesc));
-            entityManager.flush();
 
             // then (DB 데이터 변경 확인)
-            String selectSql = "SELECT name, description FROM blog_category WHERE code = ?";
-            Map<String, Object> result = jdbcTemplate.queryForMap(selectSql, code);
-
+            Map<String, Object> result = jdbcTemplate.queryForMap(
+                    "SELECT name, description FROM blog_category WHERE code = ?", code);
             assertThat(result.get("name")).isEqualTo(updateName);
             assertThat(result.get("description")).isEqualTo(updateDesc);
         }
@@ -155,23 +138,15 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
                 String expectedErrorMessage
         ) {
             // given
-            // 필요한 경우 사전 데이터 세팅
             String code = "VALID_TEST";
-            String insertSql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-
-            try {
-                jdbcTemplate.update(insertSql, code, "Original", "Original Description");
-            } catch (Exception e) {
-                // 데이터가 DB에 이미 존재 시 무시
-            }
-
-            var requestDto = CategoryRequest.CategoryUpdateDto.of(name, description);
+            jdbcTemplate.update(CategoryMother.INSERT_SQL,
+                    CategoryMother.fullParams(code, "Original", "Original Description"));
 
             // when & then
             RestAssuredMockMvc
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(requestDto)
+                    .body(CategoryMother.updateDto(name, description))
                     .when()
                     .put("/categories/{code}", code)
                     .then()
@@ -193,14 +168,6 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
     @DisplayName("Category 조회 통합 테스트")
     class GetCategory {
 
-        @BeforeEach
-        void setUp() {
-            RestAssuredMockMvc.mockMvc(mockMvc);
-            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=0");
-            jdbcTemplate.execute("TRUNCATE TABLE blog_category");
-            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS=1");
-        }
-
         @DisplayName("[통합] GET /categories/{code} - 단건 조회 성공 [200 OK]")
         @Test
         void getCategory_Integration_Success() {
@@ -208,9 +175,7 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
             String code = "READ_TEST";
             String name = "Read Name";
             String description = "Read Desc";
-
-            String insertSql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            jdbcTemplate.update(insertSql, code, name, description);
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.fullParams(code, name, description));
 
             // when & then
             RestAssuredMockMvc
@@ -245,10 +210,9 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
         @Test
         void getCategories_Integration_Success() {
             // given
-            String insertSql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            jdbcTemplate.update(insertSql, "SEARCH_1", "Search Target 1", "Desc 1");
-            jdbcTemplate.update(insertSql, "SEARCH_2", "Search Target 2", "Desc 2");
-            jdbcTemplate.update(insertSql, "OTHER_3", "Other Category", "Desc 3");
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.fullParams("SEARCH_1", "Search Target 1", "Desc 1"));
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.fullParams("SEARCH_2", "Search Target 2", "Desc 2"));
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.fullParams("OTHER_3", "Other Category", "Desc 3"));
 
             // when & then
             RestAssuredMockMvc
@@ -260,7 +224,7 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
                     .get("/categories")
                     .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body("content.size()", equalTo(2)) // 2개만 조회되어야 함
+                    .body("content.size()", equalTo(2))
                     .body("content[0].categoryCode", equalTo("SEARCH_1"))
                     .body("content[1].categoryCode", equalTo("SEARCH_2"))
                     .body("totalElements", equalTo(2));
@@ -269,15 +233,14 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
         @DisplayName("[통합] GET /categories - 페이징 및 정렬 동작 확인 [200 OK]")
         @Test
         void getCategories_Integration_PagingAndSorting() {
-            // given
-            //테스트 데이터 15개
-            String insertSql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
+            // given — 테스트 데이터 15개
             for (int i = 1; i <= 15; i++) {
                 String suffix = String.format("%02d", i);
-                jdbcTemplate.update(insertSql, "CODE" + suffix, "Name" + suffix,"Desc" + suffix);
+                jdbcTemplate.update(CategoryMother.INSERT_SQL,
+                        CategoryMother.fullParams("CODE" + suffix, "Name" + suffix, "Desc" + suffix));
             }
-            // when & then
-            // 첫 번째 페이지 조회 (size=10, name 역순 정렬)
+
+            // when & then — 첫 번째 페이지 (size=10, name 역순)
             RestAssuredMockMvc
                     .given()
                     .param("page", 0)
@@ -314,13 +277,10 @@ public class CategoryIntegrationTest extends IntegrationTestSupport {
         @DisplayName("[통합] GET /categories - 검색 결과가 없을 경우 빈 목록 반환 [200 OK]")
         @Test
         void getCategories_Integration_EmptyResult() {
-            // given
-            // 데이터가 없는 상태 (또는 검색 조건에 맞지 않는 데이터만 있는 상태)
-
             // when & then
             RestAssuredMockMvc
                     .given()
-                    .param("name", "NonExistentName") // 존재하지 않는 이름으로 검색
+                    .param("name", "NonExistentName")
                     .when()
                     .get("/categories")
                     .then()

--- a/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
@@ -1,9 +1,10 @@
 package com.jk.amazon2.member.integration;
 
-import com.jk.amazon2.member.dto.MemberRequest;
 import com.jk.amazon2.category.exception.CategoryErrorCode;
 import com.jk.amazon2.member.exception.MemberErrorCode;
+import com.jk.amazon2.testsupport.CategoryMother;
 import com.jk.amazon2.testsupport.IntegrationTestSupport;
+import com.jk.amazon2.testsupport.MemberMother;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import net.datafaker.Faker;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -28,8 +28,6 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
     private MockMvc mockMvc;
     @Autowired
     private JdbcTemplate jdbcTemplate;
-    @Autowired
-    private EntityManager em;
 
     private final Faker faker = new Faker(Locale.of("ko"));
 
@@ -46,24 +44,16 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         void createMember_Integration_Success() {
             // given
             String categoryCode = "DEV_TEST";
-            String categoryName = "개발";
-            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertCategorySql, categoryCode, categoryName, "카테고리");
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.defaultParams(categoryCode, "개발"));
 
             String nickname = faker.name().fullName();
             if (nickname.length() > 50) nickname = nickname.substring(0, 50);
-
-            var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
 
             // when & then (API 검증)
             RestAssuredMockMvc
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(requestDto)
+                    .body(MemberMother.createDto(nickname, categoryCode))
                     .when()
                     .post("/members")
                     .then()
@@ -72,8 +62,9 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     .body("categoryCode", equalTo(categoryCode));
 
             // then (DB 검증)
-            String selectSql = "SELECT count(*) FROM member WHERE nickname = ? AND category_code = ?";
-            Integer count = jdbcTemplate.queryForObject(selectSql, Integer.class, nickname, categoryCode);
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT count(*) FROM member WHERE nickname = ? AND category_code = ?",
+                    Integer.class, nickname, categoryCode);
             assertThat(count).isEqualTo(1);
         }
 
@@ -82,28 +73,16 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         void createMember_Integration_Fail_DuplicateNickname() {
             // given
             String categoryCode = "DEV_DUP";
-            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertCategorySql, categoryCode, "중복테스트용", "설명");
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.defaultParams(categoryCode, "중복테스트용"));
 
             String nickname = "duplicate_user";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
-
-            var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams(nickname, categoryCode));
 
             // when & then
             RestAssuredMockMvc
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(requestDto)
+                    .body(MemberMother.createDto(nickname, categoryCode))
                     .when()
                     .post("/members")
                     .then()
@@ -118,13 +97,12 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             // given
             String categoryCode = "UNKNOWN";
             String nickname = "new_user";
-            var requestDto = new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
 
             // when & then
             RestAssuredMockMvc
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(requestDto)
+                    .body(MemberMother.createDto(nickname, categoryCode))
                     .when()
                     .post("/members")
                     .then()
@@ -140,12 +118,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertCategorySql, categoryCode, "팀", "팀 카테고리");
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.defaultParams(categoryCode, "팀"));
         }
 
         @DisplayName("[통합] GET /members/{nickname} - 회원 단건 조회 성공 [200 OK]")
@@ -153,8 +126,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         void getMember_Integration_Success() {
             // given
             String nickname = "test_user_001";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams(nickname, categoryCode));
 
             // when & then
             RestAssuredMockMvc
@@ -171,9 +143,8 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         @Test
         void getMembers_Integration_Success() {
             // given
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
             for (int i = 0; i < 5; i++) {
-                jdbcTemplate.update(insertMemberSql, "user_" + i, categoryCode);
+                jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams("user_" + i, categoryCode));
             }
 
             // when & then
@@ -191,9 +162,8 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         @Test
         void getMembers_Integration_Filter_Nickname() {
             // given
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, "filter_user", categoryCode);
-            jdbcTemplate.update(insertMemberSql, "other_user", categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams("filter_user", categoryCode));
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams("other_user", categoryCode));
 
             // when & then
             RestAssuredMockMvc
@@ -211,9 +181,8 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         @Test
         void getMembers_Integration_Filter_Status() {
             // given
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, ?, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, "active_user", categoryCode, false);
-            jdbcTemplate.update(insertMemberSql, "deleted_user", categoryCode, true);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams("active_user", categoryCode));
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.deletedParams("deleted_user", categoryCode));
 
             // when & then
             RestAssuredMockMvc
@@ -236,13 +205,8 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertCategorySql, categoryCode, "개발", "개발팀");
-                jdbcTemplate.update(insertCategorySql, "DESIGN", "디자인", "디자인팀");
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.defaultParams(categoryCode, "개발"));
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.defaultParams("DESIGN", "디자인"));
         }
 
         @DisplayName("[통합] PUT /members/{nickname} - 회원 수정 성공 [200 OK]")
@@ -250,18 +214,16 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         void updateMember_Integration_Success() {
             // given
             String nickname = "original_user";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams(nickname, categoryCode));
 
             String updatedNickname = "updated_user";
             String updatedCategoryCode = "DESIGN";
-            var requestDto = new MemberRequest.MemberDto(updatedNickname, null, updatedCategoryCode);
 
             // when & then
             RestAssuredMockMvc
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(requestDto)
+                    .body(MemberMother.updateDto(updatedNickname, updatedCategoryCode))
                     .when()
                     .put("/members/{nickname}", nickname)
                     .then()
@@ -278,23 +240,17 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertCategorySql, categoryCode, "개발", "개발팀");
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.defaultParams(categoryCode, "개발"));
         }
 
         @DisplayName("[통합] PATCH /members/{nickname}/restore - soft delete된 회원 복구 성공 [204 No Content]")
         @Test
         void restoreMember_Integration_Success() {
-            // Given
+            // given
             String nickname = "restore_user";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, true, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.deletedParams(nickname, categoryCode));
 
-            // When & Then (API 검증)
+            // when & then (API 검증)
             RestAssuredMockMvc
                     .given()
                     .when()
@@ -303,19 +259,18 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
             // DB 검증 - deleted = false
-            em.flush();
-            String selectSql = "SELECT deleted FROM member WHERE nickname = ?";
-            Boolean deleted = jdbcTemplate.queryForObject(selectSql, Boolean.class, nickname);
+            Boolean deleted = jdbcTemplate.queryForObject(
+                    "SELECT deleted FROM member WHERE nickname = ?", Boolean.class, nickname);
             assertThat(deleted).isFalse();
         }
 
         @DisplayName("[통합] PATCH /members/{nickname}/restore - 존재하지 않는 회원 복구 실패 [404 Not Found]")
         @Test
         void restoreMember_Integration_Fail_NotFound() {
-            // Given
+            // given
             String nickname = "non_existent_restore_user";
 
-            // When & Then
+            // when & then
             RestAssuredMockMvc
                     .given()
                     .when()
@@ -328,12 +283,11 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         @DisplayName("[통합] PATCH /members/{nickname}/restore - 이미 활성 상태인 회원 복구 실패 [400 Bad Request]")
         @Test
         void restoreMember_Integration_Fail_AlreadyActive() {
-            // Given
+            // given
             String nickname = "already_active_user";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams(nickname, categoryCode));
 
-            // When & Then
+            // when & then
             RestAssuredMockMvc
                     .given()
                     .when()
@@ -351,12 +305,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
 
         @BeforeEach
         void setUp() {
-            String insertCategorySql = "INSERT INTO blog_category (code, name, description, created_at, created_by) VALUES (?, ?, ?, NOW(), 'system')";
-            try {
-                jdbcTemplate.update(insertCategorySql, categoryCode, "개발", "개발팀");
-            } catch (Exception e) {
-                // 이미 존재하면 무시
-            }
+            jdbcTemplate.update(CategoryMother.INSERT_SQL, CategoryMother.defaultParams(categoryCode, "개발"));
         }
 
         @DisplayName("[통합] DELETE /members/{nickname} - 회원 소프트 삭제 성공 [204 No Content]")
@@ -364,8 +313,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         void deleteMember_Integration_Success() {
             // given
             String nickname = "delete_user";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams(nickname, categoryCode));
 
             // when & then
             RestAssuredMockMvc
@@ -375,10 +323,9 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
-            // DB 검증 - deleted = true (JPA flush 후 확인)
-            em.flush();
-            String selectDeletedSql = "SELECT deleted FROM member WHERE nickname = ?";
-            Boolean deleted = jdbcTemplate.queryForObject(selectDeletedSql, Boolean.class, nickname);
+            // DB 검증 - deleted = true
+            Boolean deleted = jdbcTemplate.queryForObject(
+                    "SELECT deleted FROM member WHERE nickname = ?", Boolean.class, nickname);
             assertThat(deleted).isTrue();
         }
 
@@ -387,8 +334,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         void hardDeleteMember_Integration_Success() {
             // given
             String nickname = "hard_delete_user";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, ?, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, nickname, categoryCode, true);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.deletedParams(nickname, categoryCode));
 
             // when & then
             RestAssuredMockMvc
@@ -398,10 +344,9 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
                     .then()
                     .statusCode(HttpStatus.NO_CONTENT.value());
 
-            // DB 검증 - 완전 삭제 (JPA flush 후 확인)
-            em.flush();
-            String selectSql = "SELECT count(*) FROM member WHERE nickname = ?";
-            Integer count = jdbcTemplate.queryForObject(selectSql, Integer.class, nickname);
+            // DB 검증 - 완전 삭제
+            Integer count = jdbcTemplate.queryForObject(
+                    "SELECT count(*) FROM member WHERE nickname = ?", Integer.class, nickname);
             assertThat(count).isEqualTo(0);
         }
 
@@ -410,8 +355,7 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
         void hardDeleteMember_Integration_Fail_NotDeleted() {
             // given
             String nickname = "not_deleted_user";
-            String insertMemberSql = "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) VALUES (?, ?, false, NOW(), 'system', NOW(), 'system')";
-            jdbcTemplate.update(insertMemberSql, nickname, categoryCode);
+            jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams(nickname, categoryCode));
 
             // when & then
             RestAssuredMockMvc

--- a/src/test/java/com/jk/amazon2/testsupport/CategoryMother.java
+++ b/src/test/java/com/jk/amazon2/testsupport/CategoryMother.java
@@ -1,0 +1,26 @@
+package com.jk.amazon2.testsupport;
+
+import com.jk.amazon2.category.dto.CategoryRequest;
+
+public class CategoryMother {
+
+    public static final String INSERT_SQL =
+            "INSERT INTO blog_category (code, name, description, created_at, created_by) " +
+            "VALUES (?, ?, ?, NOW(), 'system')";
+
+    public static Object[] defaultParams(String code, String name) {
+        return new Object[]{code, name, code + " 설명"};
+    }
+
+    public static Object[] fullParams(String code, String name, String description) {
+        return new Object[]{code, name, description};
+    }
+
+    public static CategoryRequest.CategoryCreateDto createDto(String code, String name, String description) {
+        return new CategoryRequest.CategoryCreateDto(code, name, description);
+    }
+
+    public static CategoryRequest.CategoryUpdateDto updateDto(String name, String description) {
+        return CategoryRequest.CategoryUpdateDto.of(name, description);
+    }
+}

--- a/src/test/java/com/jk/amazon2/testsupport/DatabaseCleanupService.java
+++ b/src/test/java/com/jk/amazon2/testsupport/DatabaseCleanupService.java
@@ -1,0 +1,32 @@
+package com.jk.amazon2.testsupport;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+@Component
+@ActiveProfiles("test")
+public class DatabaseCleanupService {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    // FK 의존 순서: posting_error/dead_letter → posting → batch_execution → member → blog_category
+    private static final List<String> TABLE_NAMES = List.of(
+            "posting_error",
+            "posting_dead_letter",
+            "posting",
+            "batch_execution",
+            "member",
+            "blog_category"
+    );
+
+    public void truncateAll() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+        TABLE_NAMES.forEach(table -> jdbcTemplate.execute("TRUNCATE TABLE " + table));
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+    }
+}

--- a/src/test/java/com/jk/amazon2/testsupport/IntegrationTestSupport.java
+++ b/src/test/java/com/jk/amazon2/testsupport/IntegrationTestSupport.java
@@ -1,17 +1,25 @@
 package com.jk.amazon2.testsupport;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @Tag("integration")
-@Transactional
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @Import({TestContainerConfig.class, TestJacksonConfig.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 public abstract class IntegrationTestSupport {
+
+    @Autowired
+    private DatabaseCleanupService databaseCleanupService;
+
+    @AfterEach
+    void cleanUp() {
+        databaseCleanupService.truncateAll();
+    }
 }

--- a/src/test/java/com/jk/amazon2/testsupport/MemberMother.java
+++ b/src/test/java/com/jk/amazon2/testsupport/MemberMother.java
@@ -1,0 +1,26 @@
+package com.jk.amazon2.testsupport;
+
+import com.jk.amazon2.member.dto.MemberRequest;
+
+public class MemberMother {
+
+    public static final String INSERT_SQL =
+            "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) " +
+            "VALUES (?, ?, ?, NOW(), 'system', NOW(), 'system')";
+
+    public static Object[] activeParams(String nickname, String categoryCode) {
+        return new Object[]{nickname, categoryCode, false};
+    }
+
+    public static Object[] deletedParams(String nickname, String categoryCode) {
+        return new Object[]{nickname, categoryCode, true};
+    }
+
+    public static MemberRequest.MemberCreateDto createDto(String nickname, String categoryCode) {
+        return new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
+    }
+
+    public static MemberRequest.MemberDto updateDto(String nickname, String categoryCode) {
+        return new MemberRequest.MemberDto(nickname, null, categoryCode);
+    }
+}

--- a/src/test/java/com/jk/amazon2/testsupport/MemberMother.java
+++ b/src/test/java/com/jk/amazon2/testsupport/MemberMother.java
@@ -5,15 +5,15 @@ import com.jk.amazon2.member.dto.MemberRequest;
 public class MemberMother {
 
     public static final String INSERT_SQL =
-            "INSERT INTO member (nickname, category_code, deleted, created_at, created_by, updated_at, updated_by) " +
-            "VALUES (?, ?, ?, NOW(), 'system', NOW(), 'system')";
+            "INSERT INTO member (nickname, name, category_code, deleted, created_at, created_by, updated_at, updated_by) " +
+            "VALUES (?, ?, ?, ?, NOW(), 'system', NOW(), 'system')";
 
     public static Object[] activeParams(String nickname, String categoryCode) {
-        return new Object[]{nickname, categoryCode, false};
+        return new Object[]{nickname, "테스터", categoryCode, false};
     }
 
     public static Object[] deletedParams(String nickname, String categoryCode) {
-        return new Object[]{nickname, categoryCode, true};
+        return new Object[]{nickname, "테스터", categoryCode, true};
     }
 
     public static MemberRequest.MemberCreateDto createDto(String nickname, String categoryCode) {


### PR DESCRIPTION
## Summary

- `IntegrationTestSupport`에서 `@Transactional` 제거 → `@AfterEach` TRUNCATE 기반 격리로 전환
- `DatabaseCleanupService` 추가: 6개 테이블을 FK 순서대로 TRUNCATE
- `MemberMother` / `CategoryMother` 추가: Object Mother 패턴으로 테스트 픽스처 중앙화
- `MemberIntegrationTest` / `CategoryIntegrationTest`: `em.flush()` 5곳 제거, `EntityManager` 의존 제거

## 변경 배경

기존 `@Transactional` 방식은 JPA flush 전 구버전 데이터를 JdbcTemplate이 읽어 `em.flush()`를 강제 호출해야 하는 테스트 smell이 있었습니다. 실제 운영과 동일한 트랜잭션 경계에서 테스트할 수 있도록 개선했습니다.

## Test plan

- [ ] `MemberIntegrationTest` 전체 통과 확인
- [ ] `CategoryIntegrationTest` 전체 통과 확인
- [ ] `em.flush()` 코드 잔존 여부 확인
- [ ] 기존 통합 테스트 리그레션 없음 확인

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)