### PR TITLE
#56: Spring Boot Actuator 추가 및 Docker HEALTHCHECK 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR /app
 RUN groupadd -r spring && useradd -r -g spring spring
 COPY --from=builder /app/build/libs/*.jar app.jar
 RUN chown spring:spring app.jar
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 USER spring:spring
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=70.0 -XX:+UseContainerSupport"
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,6 @@ RUN chown spring:spring app.jar
 USER spring:spring
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=70.0 -XX:+UseContainerSupport"
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,5 +25,14 @@ springdoc:
   swagger-ui:
     enabled: false
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never
+
 cors:
   allowed-origins: []


### PR DESCRIPTION
## 개요
라즈베리파이 배포 환경에서 컨테이너 상태 자동 감지를 위해 Spring Boot Actuator를 추가하고 Dockerfile에 HEALTHCHECK를 적용합니다.

## 변경 사항
- `build.gradle`: `spring-boot-starter-actuator` 의존성 추가
- `application.yml`: `/actuator/health` 엔드포인트만 노출, `show-details: never` 설정
- `Dockerfile`: HEALTHCHECK 지시자 추가 + curl 설치

## 체크리스트
- [x] 구현 완료
- [x] 코드 리뷰 완료 (curl 미설치 이슈 수정)
- [ ] 단위 테스트 작성
- [ ] CI 테스트 통과
- [ ] 문서 업데이트
- [ ] 리그레션 확인

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)