### PR TITLE
#58: PostingScheduler cron 타임존 누락 수정

### DIFF
--- a/src/main/java/com/jk/amazon2/posting/scheduler/PostingScheduler.java
+++ b/src/main/java/com/jk/amazon2/posting/scheduler/PostingScheduler.java
@@ -19,7 +19,7 @@ public class PostingScheduler {
     /**
      * 매주 월요일 자정(00:00)에 지난주 데이터 수집
      */
-    @Scheduled(cron = "0 0 0 ? * MON")
+    @Scheduled(cron = "0 0 0 ? * MON", zone = "Asia/Seoul")
     public void scheduleWeeklyBatch() {
         log.info("[SCHEDULER] Weekly batch execution started");
 


### PR DESCRIPTION
## Summary

- `@Scheduled` cron 표현식에 `zone = "Asia/Seoul"` 추가
- Docker 컨테이너 기본 타임존(UTC)에 관계없이 KST 기준 월요일 00:00에 실행되도록 수정

## 원인

컨테이너 환경에서 JVM 기본 타임존이 UTC로 설정되어, 월요일 00:00 UTC(= 09:00 KST)에 실행되던 문제

## Test plan

- [ ] 로컬에서 스케줄러 zone 설정 확인
- [ ] 배포 후 월요일 00:00 KST 실행 로그 확인
- [ ] 기존 배치 로직(날짜 계산) 정상 동작 확인

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)