### PR TITLE
#60: PUT /members/{nickname} body nickname 제거 및 유효성 검사 추가

### DIFF
--- a/src/main/java/com/jk/amazon2/member/controller/MemberController.java
+++ b/src/main/java/com/jk/amazon2/member/controller/MemberController.java
@@ -61,9 +61,9 @@ public class MemberController implements MemberApiSpec {
     @PutMapping("/members/{nickname}")
     public ResponseEntity<MemberResponse.MemberUpdateDto> updateMember(
             @PathVariable String nickname,
-            @RequestBody MemberRequest.MemberDto member
+            @RequestBody @Valid MemberRequest.MemberDto member
     ) {
-        var update = MemberCommand.Update.of(nickname, member.nickname(), member.name(), member.categoryCode());
+        var update = MemberCommand.Update.of(nickname, member.name(), member.categoryCode());
 
         var response = MemberResponse.MemberUpdateDto.from(memberService.update(update));
         return ResponseEntity

--- a/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberCommand.java
@@ -23,10 +23,6 @@ public class MemberCommand {
             return new Create(nickname, name, categoryCode);
         }
 
-        public static Create from(MemberRequest.MemberDto dto) {
-            return new Create(dto.nickname(), dto.name(), dto.categoryCode());
-        }
-
         private Create(String nickname, String name, String categoryCode) {
             if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Create - Invalid nickname. nickname={}", nickname);
@@ -47,24 +43,19 @@ public class MemberCommand {
     public static class Update {
 
         private String currentNickname;
-        private String nickname;
         private String name;
         private String categoryCode;
 
-        public static Update of(String currentNickname, String nickname, String name, String categoryCode) {
-            return new Update(currentNickname, nickname, name, categoryCode);
+        public static Update of(String currentNickname, String name, String categoryCode) {
+            return new Update(currentNickname, name, categoryCode);
         }
 
-        private Update(String currentNickname, String nickname, String name, String categoryCode) {
-            if (currentNickname == null || currentNickname.isBlank()) {
+        private Update(String currentNickname, String name, String categoryCode) {
+            if (currentNickname == null || currentNickname.isBlank() || currentNickname.length() > 50) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid currentNickname. currentNickname={}", currentNickname);
                 throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
             }
-            if (nickname == null || nickname.isBlank() || nickname.length() > 50) {
-                log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid nickname. nickname={}", nickname);
-                throw new RestApiException(MemberErrorCode.MEMBER_NICKNAME_INVALID);
-            }
-            if (name != null && name.length() > 20) {
+            if (name == null || name.isBlank() || name.length() > 50) {
                 log.warn("[VALIDATION_FAILED] MemberCommand.Update - Invalid name. name={}", name);
                 throw new RestApiException(MemberErrorCode.MEMBER_NAME_INVALID);
             }
@@ -74,7 +65,6 @@ public class MemberCommand {
             }
 
             this.currentNickname = currentNickname;
-            this.nickname = nickname;
             this.name = name;
             this.categoryCode = categoryCode;
         }

--- a/src/main/java/com/jk/amazon2/member/dto/MemberRequest.java
+++ b/src/main/java/com/jk/amazon2/member/dto/MemberRequest.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.Size;
 
 public class MemberRequest {
     public record MemberDto(
-            String nickname,
+            @NotBlank(message = "이름은 필수 입니다.")
+            @Size(max = 50, message = "이름은 최대 50자까지 입력 가능합니다.")
             String name,
+            @Size(max = 10, message = "카테고리 코드는 최대 10자까지 입력 가능합니다.")
             String categoryCode
     ) {}
 

--- a/src/main/java/com/jk/amazon2/member/entity/Member.java
+++ b/src/main/java/com/jk/amazon2/member/entity/Member.java
@@ -35,10 +35,7 @@ public class Member extends BaseAudit {
         return member;
     }
 
-    public void update(String nickname, String name, String categoryCode) {
-        if (nickname != null) {
-            this.nickname = nickname;
-        }
+    public void update(String name, String categoryCode) {
         this.name = name;
         this.categoryCode = categoryCode;
     }

--- a/src/main/java/com/jk/amazon2/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/jk/amazon2/member/exception/MemberErrorCode.java
@@ -15,7 +15,7 @@ public enum MemberErrorCode implements ErrorCode{
     MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다."),
     MEMBER_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 닉네임 입니다."),
     MEMBER_CATEGORY_CODE_INVALID(HttpStatus.BAD_REQUEST, "카테고리 코드는 최대 10자까지 입력 가능합니다."),
-    MEMBER_NAME_INVALID(HttpStatus.BAD_REQUEST, "이름은 최대 20자까지 입력 가능합니다.");
+    MEMBER_NAME_INVALID(HttpStatus.BAD_REQUEST, "이름은 최대 50자까지 입력 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/jk/amazon2/member/service/MemberService.java
+++ b/src/main/java/com/jk/amazon2/member/service/MemberService.java
@@ -44,9 +44,11 @@ public class MemberService {
                 .findByNickname(command.getCurrentNickname())
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        categoryValidationPort.validateCategoryExists(command.getCategoryCode());
+        if (command.getCategoryCode() != null) {
+            categoryValidationPort.validateCategoryExists(command.getCategoryCode());
+        }
 
-        member.update(command.getNickname(), command.getName(), command.getCategoryCode());
+        member.update(command.getName(), command.getCategoryCode());
         return MemberResult.Update.of(member.getNickname(), member.getName(), member.getCategoryCode());
     }
 

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerIntegrationTest.java
@@ -56,11 +56,10 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         @DisplayName("회원 수정 성공 [success]")
         void updateMember_success() throws Exception {
             // given
-            Long memberId = 1L;
-            String nickname = "updated_member";
+            String nickname = "test_member";
             String categoryCode = "DESIGN";
 
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", categoryCode);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto("test-name", categoryCode);
             MemberResult.Update updateResult = MemberResult.Update.of(nickname, "test-name", categoryCode);
 
             given(memberService.update(any(MemberCommand.Update.class)))
@@ -81,9 +80,9 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         @DisplayName("회원 수정 성공 - categoryCode null [success]")
         void updateMember_success_with_null_categoryCode() throws Exception {
             // given
-            String nickname = "updated_member";
+            String nickname = "test_member";
 
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", null);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto("test-name", null);
             MemberResult.Update updateResult = MemberResult.Update.of(nickname, "test-name", null);
 
             given(memberService.update(any(MemberCommand.Update.class)))
@@ -102,9 +101,9 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
         @DisplayName("회원 수정 실패 케이스 [fail]")
         @ParameterizedTest(name = "[{index}] {0}")
         @MethodSource("provideUpdateMemberFailureCases")
-        void updateMember_fail(String scenario, String nickname, String categoryCode, MemberErrorCode errorCode) throws Exception {
+        void updateMember_fail(String scenario, String name, String categoryCode, MemberErrorCode errorCode) throws Exception {
             // given
-            MemberRequest.MemberDto request = new MemberRequest.MemberDto(nickname, "test-name", categoryCode);
+            MemberRequest.MemberDto request = new MemberRequest.MemberDto(name, categoryCode);
 
             given(memberService.update(any(MemberCommand.Update.class)))
                     .willThrow(new RestApiException(errorCode));
@@ -118,12 +117,12 @@ class MemberControllerIntegrationTest extends IntegrationTestSupport {
 
         private static Stream<Arguments> provideUpdateMemberFailureCases() {
             return Stream.of(
-                    Arguments.of("존재하지 않는 회원", "test_member", "DESIGN", MemberErrorCode.MEMBER_NOT_FOUND),
-                    Arguments.of("닉네임 공백", "", "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
-                    Arguments.of("닉네임 null", null, "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
-                    Arguments.of("닉네임 50자 초과", "a".repeat(51), "DESIGN", MemberErrorCode.MEMBER_NICKNAME_INVALID),
-                    Arguments.of("카테고리 코드 공백", "test_member", "", MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID),
-                    Arguments.of("카테고리 코드 10자 초과", "test_member", "a".repeat(11), MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID)
+                    Arguments.of("존재하지 않는 회원", "test-name", "DESIGN", MemberErrorCode.MEMBER_NOT_FOUND),
+                    Arguments.of("이름 null", null, "DESIGN", MemberErrorCode.MEMBER_NAME_INVALID),
+                    Arguments.of("이름 공백", "", "DESIGN", MemberErrorCode.MEMBER_NAME_INVALID),
+                    Arguments.of("이름 50자 초과", "a".repeat(51), "DESIGN", MemberErrorCode.MEMBER_NAME_INVALID),
+                    Arguments.of("카테고리 코드 공백", "test-name", "", MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID),
+                    Arguments.of("카테고리 코드 10자 초과", "test-name", "a".repeat(11), MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID)
             );
         }
     }

--- a/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/jk/amazon2/member/controller/MemberControllerTest.java
@@ -97,6 +97,54 @@ class MemberControllerTest {
     }
 
     @Nested
+    @DisplayName("Member 수정 - 단위 테스트")
+    class UpdateMember {
+        @Test
+        @DisplayName("회원 수정 성공 [success]")
+        void updateMember_success() {
+            // given
+            String nickname = "test_member";
+            var request = new MemberRequest.MemberDto("updated-name", "DESIGN");
+            var updateResult = MemberResult.Update.of(nickname, "updated-name", "DESIGN");
+
+            given(memberService.update(any(MemberCommand.Update.class)))
+                    .willReturn(updateResult);
+
+            // when
+            ResponseEntity<MemberResponse.MemberUpdateDto> response = memberController.updateMember(nickname, request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(org.springframework.http.HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().nickname()).isEqualTo(nickname);
+            assertThat(response.getBody().name()).isEqualTo("updated-name");
+            assertThat(response.getBody().categoryCode()).isEqualTo("DESIGN");
+            verify(memberService).update(any(MemberCommand.Update.class));
+        }
+
+        @DisplayName("회원 수정 실패 케이스 [fail]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideUpdateMemberFailureCases")
+        void updateMember_fail(String scenario, String currentNickname, String name, MemberErrorCode errorCode) {
+            // when & then
+            assertThatThrownBy(() -> MemberCommand.Update.of(currentNickname, name, "DEV"))
+                    .isInstanceOf(RestApiException.class)
+                    .hasMessageContaining(errorCode.getMessage());
+        }
+
+        private static Stream<Arguments> provideUpdateMemberFailureCases() {
+            return Stream.of(
+                    Arguments.of("currentNickname null", null, "valid-name", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("currentNickname 공백", "", "valid-name", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("currentNickname 50자 초과", "a".repeat(51), "valid-name", MemberErrorCode.MEMBER_NICKNAME_INVALID),
+                    Arguments.of("name null", "valid_nick", null, MemberErrorCode.MEMBER_NAME_INVALID),
+                    Arguments.of("name 공백", "valid_nick", "", MemberErrorCode.MEMBER_NAME_INVALID),
+                    Arguments.of("name 50자 초과", "valid_nick", "a".repeat(51), MemberErrorCode.MEMBER_NAME_INVALID)
+            );
+        }
+    }
+
+    @Nested
     @DisplayName("Member 삭제 - 단위 테스트")
     class DeleteMember {
         @Test

--- a/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/jk/amazon2/member/integration/MemberIntegrationTest.java
@@ -216,19 +216,20 @@ public class MemberIntegrationTest extends IntegrationTestSupport {
             String nickname = "original_user";
             jdbcTemplate.update(MemberMother.INSERT_SQL, MemberMother.activeParams(nickname, categoryCode));
 
-            String updatedNickname = "updated_user";
+            String updatedName = "수정된-이름";
             String updatedCategoryCode = "DESIGN";
 
             // when & then
             RestAssuredMockMvc
                     .given()
                     .contentType(ContentType.JSON)
-                    .body(MemberMother.updateDto(updatedNickname, updatedCategoryCode))
+                    .body(MemberMother.updateDto(updatedName, updatedCategoryCode))
                     .when()
                     .put("/members/{nickname}", nickname)
                     .then()
                     .statusCode(HttpStatus.OK.value())
-                    .body("nickname", equalTo(updatedNickname))
+                    .body("nickname", equalTo(nickname))
+                    .body("name", equalTo(updatedName))
                     .body("categoryCode", equalTo(updatedCategoryCode));
         }
     }

--- a/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/MemberServiceTest.java
@@ -134,12 +134,11 @@ class MemberServiceTest {
         void update_success() {
             // given
             String currentNickname = "test_member";
-            String newNickname = "updated_member";
             String newName = "updated-name";
             String newCategoryCode = "UPDATED";
             Member member = Member.of(currentNickname, "test-name", "DEV");
 
-            var updateCommand = MemberCommand.Update.of(currentNickname, newNickname, newName, newCategoryCode);
+            var updateCommand = MemberCommand.Update.of(currentNickname, newName, newCategoryCode);
             given(memberRepository.findByNickname(currentNickname))
                     .willReturn(Optional.of(member));
 
@@ -148,7 +147,7 @@ class MemberServiceTest {
 
             // then
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result.nickname()).isEqualTo(newNickname);
+                softly.assertThat(result.nickname()).isEqualTo(currentNickname);
                 softly.assertThat(result.name()).isEqualTo(newName);
                 softly.assertThat(result.categoryCode()).isEqualTo(newCategoryCode);
             });
@@ -160,7 +159,7 @@ class MemberServiceTest {
         void update_fail_not_found() {
             // given
             String currentNickname = "non_existent";
-            var updateCommand = MemberCommand.Update.of(currentNickname, "updated_member", "updated-name", "UPDATED");
+            var updateCommand = MemberCommand.Update.of(currentNickname, "updated-name", "UPDATED");
 
             given(memberRepository.findByNickname(currentNickname))
                     .willReturn(Optional.empty());
@@ -178,7 +177,7 @@ class MemberServiceTest {
             String currentNickname = "test_member";
             String newCategoryCode = "NOTEXIST";
             Member member = Member.of(currentNickname, "test-name", "DEV");
-            var updateCommand = MemberCommand.Update.of(currentNickname, "updated_member", "updated-name", newCategoryCode);
+            var updateCommand = MemberCommand.Update.of(currentNickname, "updated-name", newCategoryCode);
 
             given(memberRepository.findByNickname(currentNickname))
                     .willReturn(Optional.of(member));

--- a/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
+++ b/src/test/java/com/jk/amazon2/member/service/dto/MemberCommandTest.java
@@ -103,48 +103,47 @@ class MemberCommandTest {
         @MethodSource("provideValidUpdateCommands")
         void update_success(
                 String scenario,
-                String nickname,
+                String name,
                 String categoryCode
         ) {
             // when
-            MemberCommand.Update command = MemberCommand.Update.of("currentNickname", nickname, null, categoryCode);
+            MemberCommand.Update command = MemberCommand.Update.of("currentNickname", name, categoryCode);
 
             // then
             assertThat(command).isNotNull();
             assertSoftly(softly -> {
-                softly.assertThat(command.getNickname()).isEqualTo(nickname);
+                softly.assertThat(command.getName()).isEqualTo(name);
                 softly.assertThat(command.getCategoryCode()).isEqualTo(categoryCode);
             });
         }
 
         private static Stream<Arguments> provideValidUpdateCommands() {
             return Stream.of(
-                    of("기본 성공", "updatedNickname", "DESIGN"),
-                    of("categoryCode null", "updatedNickname", null),
-                    of("categoryCode 10자", "updatedNickname", "a".repeat(10))
+                    of("기본 성공", "updatedName", "DESIGN"),
+                    of("categoryCode null", "updatedName", null),
+                    of("categoryCode 10자", "updatedName", "a".repeat(10))
             );
         }
 
-        @DisplayName("닉네임 유효성 검사 실패 케이스 [fail]")
+        @DisplayName("currentNickname 유효성 검사 실패 케이스 [fail]")
         @ParameterizedTest(name = "[{index}] {0}")
-        @MethodSource("provideInvalidUpdateNicknames")
-        void update_fail_invalid_nickname(
+        @MethodSource("provideInvalidCurrentNicknames")
+        void update_fail_invalid_currentNickname(
                 String scenario,
-                String invalidNickname,
-                String categoryCode
+                String invalidCurrentNickname
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", invalidNickname, null, categoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of(invalidCurrentNickname, "validName", "DESIGN"))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NICKNAME_INVALID.getMessage());
         }
 
-        private static Stream<Arguments> provideInvalidUpdateNicknames() {
+        private static Stream<Arguments> provideInvalidCurrentNicknames() {
             return Stream.of(
-                    of("nickname이 null인 경우", null, "DESIGN"),
-                    of("nickname이 빈 문자열인 경우", "", "DESIGN"),
-                    of("nickname이 공백인 경우", "   ", "DESIGN"),
-                    of("nickname이 50자를 초과하는 경우", "a".repeat(51), "DESIGN")
+                    of("currentNickname이 null인 경우", null),
+                    of("currentNickname이 빈 문자열인 경우", ""),
+                    of("currentNickname이 공백인 경우", "   "),
+                    of("currentNickname이 50자를 초과하는 경우", "a".repeat(51))
             );
         }
 
@@ -153,40 +152,42 @@ class MemberCommandTest {
         @MethodSource("provideInvalidUpdateCategoryCodes")
         void update_fail_invalid_categoryCode(
                 String scenario,
-                String nickname,
                 String invalidCategoryCode
         ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", nickname, null, invalidCategoryCode))
+            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", "validName", invalidCategoryCode))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_CATEGORY_CODE_INVALID.getMessage());
         }
 
         private static Stream<Arguments> provideInvalidUpdateCategoryCodes() {
             return Stream.of(
-                    of("categoryCode가 빈 문자열인 경우", "tester", ""),
-                    of("categoryCode가 공백인 경우", "tester", "   "),
-                    of("categoryCode가 10자를 초과하는 경우", "tester", "a".repeat(11))
+                    of("categoryCode가 빈 문자열인 경우", ""),
+                    of("categoryCode가 공백인 경우", "   "),
+                    of("categoryCode가 10자를 초과하는 경우", "a".repeat(11))
             );
         }
 
-        @Test
-        @DisplayName("name이 20자를 초과하면 수정 실패 [fail]")
-        void update_fail_invalid_name() {
+        @DisplayName("name 유효성 검사 실패 케이스 [fail]")
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("provideInvalidUpdateNames")
+        void update_fail_invalid_name(
+                String scenario,
+                String invalidName
+        ) {
             // when & then
-            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", "tester", "a".repeat(21), "DEV"))
+            assertThatThrownBy(() -> MemberCommand.Update.of("currentNickname", invalidName, "DEV"))
                     .isInstanceOf(RestApiException.class)
                     .hasMessageContaining(MemberErrorCode.MEMBER_NAME_INVALID.getMessage());
         }
 
-        @Test
-        @DisplayName("name이 null이면 수정 성공 (선택값) [success]")
-        void update_success_name_null() {
-            // when
-            MemberCommand.Update command = MemberCommand.Update.of("currentNickname", "tester", null, "DEV");
-
-            // then
-            assertThat(command.getName()).isNull();
+        private static Stream<Arguments> provideInvalidUpdateNames() {
+            return Stream.of(
+                    of("name이 null인 경우", null),
+                    of("name이 빈 문자열인 경우", ""),
+                    of("name이 공백인 경우", "   "),
+                    of("name이 50자를 초과하는 경우", "a".repeat(51))
+            );
         }
     }
 

--- a/src/test/java/com/jk/amazon2/testsupport/MemberMother.java
+++ b/src/test/java/com/jk/amazon2/testsupport/MemberMother.java
@@ -20,7 +20,7 @@ public class MemberMother {
         return new MemberRequest.MemberCreateDto(nickname, "테스터", categoryCode);
     }
 
-    public static MemberRequest.MemberDto updateDto(String nickname, String categoryCode) {
-        return new MemberRequest.MemberDto(nickname, null, categoryCode);
+    public static MemberRequest.MemberDto updateDto(String name, String categoryCode) {
+        return new MemberRequest.MemberDto(name, categoryCode);
     }
 }


### PR DESCRIPTION
## Summary

- `PUT /members/{nickname}` request body에서 `nickname` 필드 제거 (path param으로만 리소스 식별)
- `name` 필수 검증 추가 (`@NotBlank`, `@Size(max=50)`) + Command 생성자 이중 검증
- `categoryCode` nullable 유지, max 10 검증 추가
- null `categoryCode` 업데이트 시 카테고리 검증 포트 호출 스킵 (버그 수정)
- `MEMBER_NAME_INVALID` 에러 메시지 수정: "최대 20자" → "최대 50자"

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `MemberRequest.MemberDto` | nickname 제거, name/categoryCode 검증 추가 |
| `MemberCommand.Update` | nickname 필드 제거, currentNickname max 50 / name 필수 검증 |
| `MemberController` | `@Valid` 추가, `of()` 호출 수정 |
| `MemberService` | null categoryCode 가드 추가, `member.update()` 호출 수정 |
| `Member` | `update(String name, String categoryCode)` 시그니처 변경 |
| `MemberErrorCode` | `MEMBER_NAME_INVALID` 메시지 수정 |
| 테스트 6개 | 전체 수정 및 update 단위 테스트 추가 |

## Test plan

- [x] `MemberCommandTest` — currentNickname/name/categoryCode 경계값 검증
- [x] `MemberServiceTest` — update 성공/실패 시나리오
- [x] `MemberControllerTest` — update 성공/실패 단위 테스트 추가
- [x] `MemberControllerIntegrationTest` — MockMvc 통합 테스트
- [x] `MemberIntegrationTest` — 실 DB 연동 통합 테스트
- [x] 전체 단위/통합 테스트 통과 확인

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)